### PR TITLE
:art: (bot actions menu) add mat icon for delete and edit

### DIFF
--- a/apps/conv-learning-manager/src/app/app.module.ts
+++ b/apps/conv-learning-manager/src/app/app.module.ts
@@ -50,7 +50,7 @@ import { HttpClientModule } from '@angular/common/http';
 
     AppConfigurationModule.forRoot(environment, environment.production),
     DateConfigurationModule.forRoot(),
-    FirebaseConfigurationModule.forRoot(!environment.production, environment.useEmulators),
+    FirebaseConfigurationModule.forRoot(!environment.production, environment.useEnumarators),
     MultiLangModule.forRoot(true),
     // UserNavModule,
 

--- a/apps/conv-learning-manager/src/app/app.module.ts
+++ b/apps/conv-learning-manager/src/app/app.module.ts
@@ -50,7 +50,7 @@ import { HttpClientModule } from '@angular/common/http';
 
     AppConfigurationModule.forRoot(environment, environment.production),
     DateConfigurationModule.forRoot(),
-    FirebaseConfigurationModule.forRoot(!environment.production, environment.useEnumarators),
+    FirebaseConfigurationModule.forRoot(!environment.production, environment.useEmulators),
     MultiLangModule.forRoot(true),
     // UserNavModule,
 

--- a/libs/features/convs-mgr/home/src/lib/components/story-list-item/story-list-item.component.html
+++ b/libs/features/convs-mgr/home/src/lib/components/story-list-item/story-list-item.component.html
@@ -12,11 +12,11 @@
         <i class="fas fa-ellipsis-v"></i>
       </button>
       <mat-menu #menu="matMenu">
-        <button mat-menu-item>
+        <button mat-menu-item class="bot-menu-item">
           <span>Edit</span>
         </button>
-        <hr/>
-        <button mat-menu-item>
+        <hr class="bot-menu-item-separator"/>
+        <button mat-menu-item class="bot-menu-item">
           <span>Delete</span>
         </button>
       </mat-menu>

--- a/libs/features/convs-mgr/home/src/lib/components/story-list-item/story-list-item.component.html
+++ b/libs/features/convs-mgr/home/src/lib/components/story-list-item/story-list-item.component.html
@@ -8,15 +8,14 @@
           {{ story.name }} <span class="bot-number"></span>
         </h2>
       </div>
-
-
       <button mat-icon-button [matMenuTriggerFor]="menu">
-        <mat-icon>more_vert</mat-icon>
+        <i class="fas fa-ellipsis-v"></i>
       </button>
       <mat-menu #menu="matMenu">
         <button mat-menu-item>
           <span>Edit</span>
         </button>
+        <hr/>
         <button mat-menu-item>
           <span>Delete</span>
         </button>

--- a/libs/features/convs-mgr/home/src/lib/components/story-list-item/story-list-item.component.html
+++ b/libs/features/convs-mgr/home/src/lib/components/story-list-item/story-list-item.component.html
@@ -8,10 +8,18 @@
           {{ story.name }} <span class="bot-number"></span>
         </h2>
       </div>
-
-      <div class="dots">
-          <fa-icon [icon]="dotedIcon"></fa-icon>
-      </div>
+      
+      <button mat-icon-button [matMenuTriggerFor]="menu">
+        <mat-icon>more_vert</mat-icon>
+      </button>
+      <mat-menu #menu="matMenu">
+        <button mat-menu-item>
+          <span>Copy</span>
+        </button>
+        <button mat-menu-item>
+          <span>Delete</span>
+        </button>
+      </mat-menu>
     </div>
 
     <mat-card-content>

--- a/libs/features/convs-mgr/home/src/lib/components/story-list-item/story-list-item.component.html
+++ b/libs/features/convs-mgr/home/src/lib/components/story-list-item/story-list-item.component.html
@@ -8,13 +8,13 @@
           {{ story.name }} <span class="bot-number"></span>
         </h2>
       </div>
-      
+
       <button mat-icon-button [matMenuTriggerFor]="menu">
         <mat-icon>more_vert</mat-icon>
       </button>
       <mat-menu #menu="matMenu">
         <button mat-menu-item>
-          <span>Copy</span>
+          <span>Edit</span>
         </button>
         <button mat-menu-item>
           <span>Delete</span>

--- a/libs/features/convs-mgr/home/src/lib/components/story-list-item/story-list-item.component.scss
+++ b/libs/features/convs-mgr/home/src/lib/components/story-list-item/story-list-item.component.scss
@@ -31,14 +31,6 @@
   font-size: x-small;
 }
 
-.btn-dotted{
-  height: 5px;
-  width: 5px;
-  background-color: mat-color($mat-ele, 500);
-  border-radius: 50%;
-  margin: 2px 0;
-}
-
 .bot-menu-item-separator{
   margin: 0;
   background-color: var(--convs-mgr-color-light);
@@ -46,13 +38,4 @@
 
 .bot-menu-item{
   text-align: center;
-}
-
-.dots{
-margin-top: 7px;
-
-}
-
-.dots:hover{
-  cursor: pointer;
 }

--- a/libs/features/convs-mgr/home/src/lib/components/story-list-item/story-list-item.component.scss
+++ b/libs/features/convs-mgr/home/src/lib/components/story-list-item/story-list-item.component.scss
@@ -39,6 +39,15 @@
   margin: 2px 0;
 }
 
+.bot-menu-item-separator{
+  margin: 0;
+  background-color: var(--convs-mgr-color-light);
+}
+
+.bot-menu-item{
+  text-align: center;
+}
+
 .dots{
 margin-top: 7px;
 

--- a/libs/features/convs-mgr/home/src/lib/components/story-list-item/story-list-item.component.scss
+++ b/libs/features/convs-mgr/home/src/lib/components/story-list-item/story-list-item.component.scss
@@ -38,4 +38,6 @@
 
 .bot-menu-item{
   text-align: center;
+  font-weight: 700;
+  color: var(--convs-mgr-color-text-black);
 }


### PR DESCRIPTION
# Description
Change three dot menu on bot card to use angular material with a menu for delete and copy
Fixes #102

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue.

# Screenshot (optional)
![bot_actions_menu](https://user-images.githubusercontent.com/38103061/196635334-e08f0f72-d52a-4dad-910c-090851138d96.png)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code

