### PR TITLE
:wrench:  fix: added modal feature to 'create-my-first-bot' card

### DIFF
--- a/libs/features/convs-mgr/stories/home/src/lib/components/story-list/story-list.component.html
+++ b/libs/features/convs-mgr/stories/home/src/lib/components/story-list/story-list.component.html
@@ -1,15 +1,11 @@
 <!-- edited the search -->
 <div class="search">
-  <i class="fas fa-search">        
+  <i class="fas fa-search">
   </i>
-  <input type="text" name="" placeholder="Search for a bot" (input)="filterBots($event)"/>
+  <input type="text" name="" placeholder="Search for a bot" (input)="filterBots($event)" />
 </div>
 
-<div *ngIf="stories$ | async as stories"
-  class="bot-selector"
-  fxLayout="row wrap"
-  fxFlexFill
->
+<div *ngIf="stories$ | async as stories" class="bot-selector" fxLayout="row wrap" fxFlexFill>
   <div *ngIf="stories.length > 0; else noBots" fxLayout="row wrap" fxFlex>
     <div *ngFor="let story of stories" fxFlex="24">
       <convl-story-list-item [story]="story"> </convl-story-list-item>
@@ -18,12 +14,11 @@
 </div>
 
 <ng-template #noBots>
-  <mat-card class="create-bot">
+  <mat-card class="create-bot" (click)="openCreateDialog()">
     <mat-card-title><i class="fa fa-plus fa-5x" aria-hidden="true"></i>
     </mat-card-title>
-      <mat-card-content>
-        <p>Create my first bot!</p>
-      </mat-card-content>
+    <mat-card-content>
+      <p>Create my first bot!</p>
+    </mat-card-content>
   </mat-card>
 </ng-template>
-

--- a/libs/features/convs-mgr/stories/home/src/lib/components/story-list/story-list.component.scss
+++ b/libs/features/convs-mgr/stories/home/src/lib/components/story-list/story-list.component.scss
@@ -52,6 +52,7 @@
   margin-left: 24em;
   margin-top: 12em;
   margin-right: 23em;
+  cursor: pointer;
 }
 .create-bot p{
   padding-left: 1em;

--- a/libs/features/convs-mgr/stories/home/src/lib/components/story-list/story-list.component.ts
+++ b/libs/features/convs-mgr/stories/home/src/lib/components/story-list/story-list.component.ts
@@ -3,6 +3,10 @@ import { BehaviorSubject, combineLatest, map, Observable } from 'rxjs';
 import { StoriesStore } from '@app/state/convs-mgr/stories';
 import { Story } from '@app/model/convs-mgr/stories/main';
 
+import { MatDialog } from '@angular/material/dialog';
+import { SubSink } from 'subsink';
+import { CreateBotModalComponent } from '../../modals/create-bot-modal/create-bot-modal.component';
+
 @Component({
   selector: 'convl-italanta-apps-story-list',
   templateUrl: './story-list.component.html',
@@ -12,7 +16,9 @@ export class StoryListComponent implements OnInit {
   stories$: Observable<Story[]>;
   filterInput$$: BehaviorSubject<string> = new BehaviorSubject<string>('');
 
-  constructor(private _stories$$: StoriesStore) {
+  private _sb = new SubSink();
+
+  constructor(private _stories$$: StoriesStore, private dialog : MatDialog) {
     this.stories$ = this._stories$$.get();
   }
   ngOnInit(): void {
@@ -30,5 +36,20 @@ export class StoryListComponent implements OnInit {
   }
   filterBots(event: any) {
     this.filterInput$$.next(event.target.value);
+  }
+
+  openCreateDialog(){
+    this.dialog.open(CreateBotModalComponent, {
+      data: {
+        isEditMode: false,
+      },
+      minHeight: 'fit-content',
+      minWidth: '600px'
+    });
+  }
+
+  ngOnDestroy()
+  {
+    this._sb.unsubscribe();
   }
 }


### PR DESCRIPTION
# Description

This is more of a fix and enhancement from a closed issue (#72 )

I noticed that when you click on the **create my first bot!** card in the `Active Bots>Dashboard` page, it doesn't pop up the `CreateBotModalComponent` as expected.

To fix this, I reused the `openCreateDialog()` function in CreateBotModalComponent and attached it to the Card through a click event.

This PR fixes and enhances a closed issue #72 

## Type of change

- [x] Enhancement

# Video

https://user-images.githubusercontent.com/72970552/210243740-8a36420b-61fa-4a9f-b484-75c6b2a23766.mp4

# How Has This Been Tested?

No test required as this is an UI enhancement

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
