### PR TITLE
🐛 Fix delete block not working

### DIFF
--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.html
@@ -8,7 +8,7 @@
         
             <div fxLayout="row" class="icon-block">
                 <span class="icons"><i class="far fa-clone"></i></span>
-                <span class="icons"><i (click)="deleteBlock()" class="far fa-trash-alt"></i></span>
+                <span (click)="deleteBlock()" class="icons"><i class="far fa-trash-alt"></i></span>
             </div>
         </div>
 


### PR DESCRIPTION
# Description

Delete block function was not working. Fixed it by moving it to the span wrapping the icon