### PR TITLE
🧱 🖊️  Open ended Qstns edit forms

### DIFF
--- a/apps/conv-learning-manager/src/assets/i18n/en.json
+++ b/apps/conv-learning-manager/src/assets/i18n/en.json
@@ -80,7 +80,7 @@
         "DOCUMENT": "Document",
         "MULTIPLEINPUT":"Multiple-Input",
         "IMAGE-INPUT":"Image Input",
-        "OPEN-ENDED-QUESTION": "Open Emded Question"
+        "OPEN-ENDED-QUESTION": "Open Ended Question"
       },
       "PLACEHOLDER": {
         "ANCHOR": "Start here",

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/index.ts
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/index.ts
@@ -1,5 +1,6 @@
 export * from './lib/convs-mgr-edit-block-module';
 export * from './lib/components/default/default.component';
+export * from './lib/components/open-ended-question-edit/open-ended-question-edit.component';
 export * from './lib/components/message-block-edit/message-block-edit.component';
 export * from './lib/components/email-block-edit/email-block-edit.component';
 export * from './lib/components/message-block-edit/message-block-edit.component';

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
@@ -1,0 +1,6 @@
+<div class="form-wrapper">
+  <form [formGroup]="form" action="" class="form-edit">
+    <span class="title">Message Block</span>
+    <textarea class="text" id="message" name="message" formControlName="message" rows="3"></textarea>
+  </form>
+</div>

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
@@ -1,6 +1,6 @@
 <div class="form-wrapper">
   <form [formGroup]="form" action="" class="form-edit">
-    <span class="title">Open-Ended Question</span>
+    <span class="title">{{ title | transloco }}</span>
     <textarea class="text" id="message" name="message" formControlName="message" rows="3"></textarea>
   </form>
 </div>

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
@@ -1,6 +1,6 @@
 <div class="form-wrapper">
   <form [formGroup]="form" action="" class="form-edit">
-    <span class="title">Message Block</span>
+    <span class="title">Open-Ended Question</span>
     <textarea class="text" id="message" name="message" formControlName="message" rows="3"></textarea>
   </form>
 </div>

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.scss
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.scss
@@ -1,0 +1,28 @@
+.form-wrapper {
+  display: grid;
+  justify-content: center;
+  margin: 0;
+  padding: 0.5rem;
+  overflow-y: hidden;
+
+  .form-edit {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    padding: 0.5rem;
+    width: 90%;
+
+    .title {
+      font-weight: bold;
+      font-size: 0.8rem;
+    }
+
+    .text {
+      border: 2px solid var(--convs-mgr-color-primary-purple);
+      background: transparent;
+      border-radius: 5px;
+      padding: 1rem;
+    }
+  }
+}

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'app-open-ended-question-edit',
+  templateUrl: './open-ended-question-edit.component.html',
+  styleUrls: ['./open-ended-question-edit.component.scss'],
+})
+export class OpenEndedQuestionEditComponent {
+  @Input() form:FormGroup;
+}

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.ts
@@ -8,4 +8,5 @@ import { FormGroup } from '@angular/forms';
 })
 export class OpenEndedQuestionEditComponent {
   @Input() form:FormGroup;
+  @Input() title: string;
 }

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/convs-mgr-edit-block-module.ts
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/convs-mgr-edit-block-module.ts
@@ -1,6 +1,8 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { OpenEndedQuestionEditComponent } from './components/open-ended-question-edit/open-ended-question-edit.component';
 import { MessageBlockEditComponent } from './components/message-block-edit/message-block-edit.component';
 import { EmailBlockEditComponent } from './components/email-block-edit/email-block-edit.component';
 import { PhoneBlockEditComponent } from './components/phone-block-edit/phone-block-edit.component';
@@ -11,6 +13,7 @@ import { DefaultComponent } from './components/default/default.component';
   imports: [CommonModule, FormsModule, ReactiveFormsModule],
 
   declarations: [
+    OpenEndedQuestionEditComponent,
     MessageBlockEditComponent,
     NameBlockEditComponent,
     EmailBlockEditComponent,

--- a/libs/features/convs-mgr/stories/editor/src/lib/providers/fetch-active-block-component.function.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/providers/fetch-active-block-component.function.ts
@@ -1,4 +1,6 @@
 import { StoryBlockTypes } from '@app/model/convs-mgr/stories/blocks/main';
+
+import { OpenEndedQuestionEditComponent } from '@app/features/convs-mgr/stories/blocks/edit/blocks-edit';
 import { MessageBlockEditComponent } from '@app/features/convs-mgr/stories/blocks/edit/blocks-edit';
 import { EmailBlockEditComponent } from '@app/features/convs-mgr/stories/blocks/edit/blocks-edit';
 import { NameBlockEditComponent } from '@app/features/convs-mgr/stories/blocks/edit/blocks-edit';
@@ -50,7 +52,7 @@ export function getActiveBlock(type: StoryBlockTypes) {
     case StoryBlockTypes.EndStoryAnchorBlock:
       return DefaultComponent;
     case StoryBlockTypes.OpenEndedQuestion:
-      return DefaultComponent;
+      return OpenEndedQuestionEditComponent;
     default:
       return DefaultComponent;
   }


### PR DESCRIPTION
# Description
Add Open ended Qstns block edit form. depends on #288 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# Screenshot(Optional)

![Screenshot (5)](https://user-images.githubusercontent.com/20738858/217823546-0bbb8898-1fa5-433e-a7ad-22109b13c4a0.png)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

