### PR TITLE
316/text message component

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -336,6 +336,34 @@
     "features-convs-mgr-stories-blocks-library-reply-message-block": "libs/features/convs-mgr/stories/blocks/library/reply-message-block",
     "features-convs-mgr-stories-blocks-library-sticker-message-block": "libs/features/convs-mgr/stories/blocks/library/sticker-message-block",
     "features-convs-mgr-stories-blocks-library-text-message-block": "libs/features/convs-mgr/stories/blocks/library/text-message-block",
+    "features-convs-mgr-stories-blocks-library-text-message-options": {
+      "projectType": "library",
+      "root": "libs/features/convs-mgr/stories/blocks/library/text-message-options",
+      "sourceRoot": "libs/features/convs-mgr/stories/blocks/library/text-message-options/src",
+      "prefix": "app",
+      "targets": {
+        "test": {
+          "executor": "@nrwl/jest:jest",
+          "outputs": [
+            "coverage/libs/features/convs-mgr/stories/blocks/library/text-message-options"
+          ],
+          "options": {
+            "jestConfig": "libs/features/convs-mgr/stories/blocks/library/text-message-options/jest.config.ts",
+            "passWithNoTests": true
+          }
+        },
+        "lint": {
+          "executor": "@nrwl/linter:eslint",
+          "options": {
+            "lintFilePatterns": [
+              "libs/features/convs-mgr/stories/blocks/library/text-message-options/**/*.ts",
+              "libs/features/convs-mgr/stories/blocks/library/text-message-options/**/*.html"
+            ]
+          }
+        }
+      },
+      "tags": []
+    },
     "features-convs-mgr-stories-blocks-library-video-input-block": {
       "projectType": "library",
       "root": "libs/features/convs-mgr/stories/blocks/library/video-input-block",

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-block/src/lib/components/message-block/message-block.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-block/src/lib/components/message-block/message-block.component.html
@@ -1,7 +1,6 @@
 <div [id]="id" *ngIf="textMessageForm">
 	<form [formGroup]="textMessageForm" fxLayout="column" fxLayoutALign="start center">
-		<textarea id="message" name="message" formControlName="message" type="text" rows="3"></textarea>
-
+    <app-text-message [form]="textMessageForm"></app-text-message>
 		<app-default-option-field [jsPlumb]="jsPlumb" [blockFormGroup]="textMessageForm"></app-default-option-field>
 	</form>
 </div>

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-block/src/lib/components/message-block/message-block.component.scss
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-block/src/lib/components/message-block/message-block.component.scss
@@ -1,5 +1,5 @@
 mat-card {
-  min-width:200px;  
+  min-width:200px;
 }
 
 .mat-card-title {
@@ -7,13 +7,6 @@ mat-card {
   color: #6418C3;
 }
 
-textarea {
-  margin: 5px 0;
-  border-radius: 6px;
-  border: 2px solid #6418C3;
-  padding: 20px;
-  text-align: left;
-}
 
 input {
   text-align: center;

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-options/.eslintrc.json
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-options/.eslintrc.json
@@ -1,0 +1,36 @@
+{
+  "extends": ["../../../../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nrwl/nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "app",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "app",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nrwl/nx/angular-template"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-options/README.md
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-options/README.md
@@ -1,0 +1,7 @@
+# features-convs-mgr-stories-blocks-library-text-message-options
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test features-convs-mgr-stories-blocks-library-text-message-options` to execute the unit tests.

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-options/jest.config.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-options/jest.config.ts
@@ -1,0 +1,23 @@
+/* eslint-disable */
+export default {
+  displayName: 'features-convs-mgr-stories-blocks-library-text-message-options',
+  preset: '../../../../../../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+      stringifyContentPathRegex: '\\.(html|svg)$',
+    },
+  },
+  coverageDirectory:
+    '../../../../../../../coverage/libs/features/convs-mgr/stories/blocks/library/text-message-options',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': 'jest-preset-angular',
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-options/src/index.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-options/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/convs-mgr-text-message-options.module';

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-options/src/lib/components/text-message/text-message.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-options/src/lib/components/text-message/text-message.component.html
@@ -1,0 +1,3 @@
+<form [formGroup]="form">
+  <textarea id="message" name="message" formControlName="message" type="text" rows="3"></textarea>
+</form>

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-options/src/lib/components/text-message/text-message.component.scss
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-options/src/lib/components/text-message/text-message.component.scss
@@ -1,0 +1,8 @@
+ textarea{
+  margin: 5px 0;
+  border-radius: 6px;
+  border: 2px solid #6418c3;
+  padding: 20px;
+  text-align: left;
+}
+

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-options/src/lib/components/text-message/text-message.component.spec.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-options/src/lib/components/text-message/text-message.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TextMessageComponent } from './text-message.component';
+
+describe('TextMessageComponent', () => {
+  let component: TextMessageComponent;
+  let fixture: ComponentFixture<TextMessageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TextMessageComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TextMessageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-options/src/lib/components/text-message/text-message.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-options/src/lib/components/text-message/text-message.component.ts
@@ -1,0 +1,11 @@
+import { Component, Input } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'app-text-message',
+  templateUrl: './text-message.component.html',
+  styleUrls: ['./text-message.component.scss'],
+})
+export class TextMessageComponent {
+  @Input () form: FormGroup;
+}

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-options/src/lib/convs-mgr-text-message-options.module.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-options/src/lib/convs-mgr-text-message-options.module.ts
@@ -1,0 +1,12 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ReactiveFormsModule, FormsModule } from '@angular/forms';
+import { TextMessageComponent } from './components/text-message/text-message.component';
+
+@NgModule({
+  imports: [CommonModule, ReactiveFormsModule, FormsModule],
+  declarations: [TextMessageComponent],
+  exports: [TextMessageComponent]
+
+})
+export class ConvsMgrTextMessageOptionsModule {}

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-options/src/test-setup.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-options/src/test-setup.ts
@@ -1,0 +1,1 @@
+import 'jest-preset-angular/setup-jest';

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-options/tsconfig.json
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-options/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "extends": "../../../../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "compilerOptions": {
+    "target": "es2020",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-options/tsconfig.lib.json
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-options/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../../../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/test-setup.ts",
+    "**/*.spec.ts",
+    "jest.config.ts",
+    "**/*.test.ts"
+  ],
+  "include": ["**/*.ts"]
+}

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-options/tsconfig.spec.json
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-options/tsconfig.spec.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": ["jest.config.ts", "**/*.test.ts", "**/*.spec.ts", "**/*.d.ts"]
+}

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -125,6 +125,9 @@
       "@app/features/convs-mgr/stories/blocks/library/text-message-block": [
         "libs/features/convs-mgr/stories/blocks/library/text-message-block/src/index.ts"
       ],
+      "@app/features/convs-mgr/stories/blocks/library/text-message-options": [
+        "libs/features/convs-mgr/stories/blocks/library/text-message-options/src/index.ts"
+      ],
       "@app/features/convs-mgr/stories/blocks/library/video-input-block": [
         "libs/features/convs-mgr/stories/blocks/library/video-input-block/src/index.ts"
       ],


### PR DESCRIPTION
# Description

This pull request refactors the message block by creating a separate text-message-options library and generating a TextMessageComponent inside the library. This will ensure reusability and easy maintainability of the 'textarea'.

Fixes #316 - Move the message (text area) field of blocks to a separate component for reuse.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
