### PR TITLE
🎨 Fix block option width being too small

### DIFF
--- a/libs/features/convs-mgr/stories/blocks/library/block-options/src/lib/components/option-input-field/option-input-field.component.scss
+++ b/libs/features/convs-mgr/stories/blocks/library/block-options/src/lib/components/option-input-field/option-input-field.component.scss
@@ -3,7 +3,7 @@
 }
 
 input {
-  width: inherit!important;
+  width: 90% !important;
   height: fit-content!important;
   min-width: auto !important;
   min-height: fit-content!important;


### PR DESCRIPTION
# Description

Fix block option width being too small by setting it to 90%.