### PR TITLE
:recycle: refactor: Remove default option on list block and question …

### DIFF
--- a/libs/features/convs-mgr/stories/blocks/library/list-message-block/src/lib/components/list-block/list-block.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/list-message-block/src/lib/components/list-block/list-block.component.html
@@ -3,8 +3,6 @@
 
     <textarea id="message" name="message" formControlName="message" type="text" rows="3"></textarea>
 
-    <app-default-option-field [jsPlumb]="jsPlumb" [blockFormGroup]="listMessageBlock"></app-default-option-field>
-
     <div formArrayName="options" fxFlexFill>
       <div *ngFor="let listItem of listItems.controls; let i = index">
         <div [formGroupName]="i" class="inputList" fxLayout="row" fxLayoutALign="start center" fxFlex="100">

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/list-block-form.model.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/list-block-form.model.ts
@@ -9,11 +9,10 @@ import { ListMessageBlock } from "@app/model/convs-mgr/stories/blocks/messaging"
  * @param blockData the data being patched into the FormGroup
  * @returns builds the formgroup with data if available and returns the Formgroup
  */
- export function _CreateListBlockMessageForm(_fb: FormBuilder, blockData: ListMessageBlock): FormGroup {
+export function _CreateListBlockMessageForm(_fb: FormBuilder, blockData: ListMessageBlock): FormGroup {
   return _fb.group({
     id: [blockData?.id! ?? ''],
     message: [blockData?.message! ?? ''],
-    defaultTarget: [''],
     options: _fb.array([]),
     type: [blockData.type ?? StoryBlockTypes.List],
     position: [blockData.position ?? { x: 200, y: 50 }]

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/questions-block-form.model.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/questions-block-form.model.ts
@@ -9,11 +9,10 @@ import { QuestionMessageBlock } from "@app/model/convs-mgr/stories/blocks/messag
  * @param blockData the data being patched into the FormGroup
  * @returns builds the formgroup with data if available and returns the Formgroup
  */
- export function _CreateQuestionBlockMessageForm(_fb: FormBuilder, blockData: QuestionMessageBlock): FormGroup {
+export function _CreateQuestionBlockMessageForm(_fb: FormBuilder, blockData: QuestionMessageBlock): FormGroup {
   return _fb.group({
     id: [blockData?.id! ?? ''],
     message: [blockData?.message! ?? ''],
-    defaultTarget: [blockData.defaultTarget ?? ''],
     options: _fb.array([]),
     type: [blockData.type ?? StoryBlockTypes.IO],
     position: [blockData.position ?? { x: 200, y: 50 }]

--- a/libs/features/convs-mgr/stories/blocks/library/question-message-block/src/lib/components/questions-block/questions-block.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/question-message-block/src/lib/components/questions-block/questions-block.component.html
@@ -3,8 +3,6 @@
 
     <textarea id="message" name="message" formControlName="message" type="text" rows="3"></textarea>
 
-    <app-default-option-field [jsPlumb]="jsPlumb" [blockFormGroup]="questionMessageBlock"></app-default-option-field>
-
     <div formArrayName="options" fxFlexFill>
       <div *ngFor="let option of options.controls; let i = index">
         <div [formGroupName]="i" class="inputList" fxLayout="row" fxLayoutALign="start center" fxFlex="100">

--- a/libs/model/convs-mgr/stories/blocks/messaging/src/lib/list-message-block.interface.ts
+++ b/libs/model/convs-mgr/stories/blocks/messaging/src/lib/list-message-block.interface.ts
@@ -1,11 +1,9 @@
 import { StoryBlock } from "@app/model/convs-mgr/stories/blocks/main";
 import { ButtonsBlockButton } from "../../../scenario/src";
-export interface ListMessageBlock extends StoryBlock{
+export interface ListMessageBlock extends StoryBlock {
 
   /** Actual question */
   message?: string;
-
-  defaultTarget?: string;
 
   /** Response options */
   options?: ButtonsBlockButton<Button>[];

--- a/libs/model/convs-mgr/stories/blocks/messaging/src/lib/question-message-block.interface.ts
+++ b/libs/model/convs-mgr/stories/blocks/messaging/src/lib/question-message-block.interface.ts
@@ -6,12 +6,10 @@ import { StoryBlock } from "@app/model/convs-mgr/stories/blocks/main";
  * Block which sends a question message in the form of text and clickable options.
  */
 
-export interface QuestionMessageBlock extends StoryBlock{
+export interface QuestionMessageBlock extends StoryBlock {
 
   /** Actual question */
   message?: string;
-
-  defaultTarget?: string;
 
   /** Response options */
   options?: ButtonsBlockButton<Button>[];


### PR DESCRIPTION
# Description

This PR is made to handle the removal of the default option component from the list and question blocks as at the moment they never gets evaluated and is not actually needed. A user should only have the option of making new connections from endpoints that are evaluated.

Fixes #337 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Screenshot
![Screenshot (373)](https://user-images.githubusercontent.com/56071589/222479538-bd7d0ca9-0c53-4e43-b4b1-9ca5fff8dd2a.png)

# How Has This Been Tested?

- [x] Run the project, created both a question and list block to check that default option no longer renders.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
