### PR TITLE
Move the message (text area) field of blocks to a separate component

### DIFF
--- a/libs/features/convs-mgr/stories/blocks/library/text-message-block/src/lib/components/message-block/message-block.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-block/src/lib/components/message-block/message-block.component.html
@@ -1,6 +1,6 @@
 <div [id]="id" *ngIf="textMessageForm">
 	<form [formGroup]="textMessageForm" fxLayout="column" fxLayoutALign="start center">
-		<textarea id="message" name="message" formControlName="message" type="text" rows="3"></textarea>
+		<app-text-message></app-text-message>
 
 		<app-default-option-field [jsPlumb]="jsPlumb" [blockFormGroup]="textMessageForm"></app-default-option-field>
 	</form>

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-block/src/lib/components/text-message/text-message.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-block/src/lib/components/text-message/text-message.component.html
@@ -1,0 +1,1 @@
+<textarea id="message" name="message" formControlName="message" type="text" rows="3"></textarea>

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-block/src/lib/components/text-message/text-message.component.spec.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-block/src/lib/components/text-message/text-message.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { TextMessageComponent } from './text-message.component';
+
+describe('TextMessageComponent', () => {
+  let component: TextMessageComponent;
+  let fixture: ComponentFixture<TextMessageComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [TextMessageComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(TextMessageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-block/src/lib/components/text-message/text-message.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-block/src/lib/components/text-message/text-message.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-text-message',
+  templateUrl: './text-message.component.html',
+  styleUrls: ['./text-message.component.scss'],
+})
+export class TextMessageComponent {}

--- a/libs/features/convs-mgr/stories/blocks/library/text-message-block/src/lib/convs-mgr-text-message-block.module.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/text-message-block/src/lib/convs-mgr-text-message-block.module.ts
@@ -11,6 +11,7 @@ import {
 import { ConvsMgrBlockOptionsModule } from '@app/features/convs-mgr/stories/blocks/library/block-options';
 
 import { MessageBlockComponent } from './components/message-block/message-block.component';
+import { TextMessageComponent } from './components/text-message/text-message.component';
 
 @NgModule({
   imports: [
@@ -22,10 +23,10 @@ import { MessageBlockComponent } from './components/message-block/message-block.
     FormsModule,
     ReactiveFormsModule,
 
-    ConvsMgrBlockOptionsModule
+    ConvsMgrBlockOptionsModule,
   ],
 
-  declarations: [MessageBlockComponent],
+  declarations: [MessageBlockComponent, TextMessageComponent],
 
   exports: [MessageBlockComponent],
 })


### PR DESCRIPTION
# Description

This PR includes a refractor that moves the messages text area to a separate component. This will ensure reusability and easy maintainability.

Fixes #316
## Screenshot:
![txtArea](https://user-images.githubusercontent.com/104300169/224101240-6aeef3f1-44fe-4b9b-a598-306e2214ccc3.png)

## Type of change

- [ ] Refractor (non-breaking change which adds functionality)
