### PR TITLE
130/sign up page

### DIFF
--- a/apps/conv-learning-manager/src/assets/i18n/en.json
+++ b/apps/conv-learning-manager/src/assets/i18n/en.json
@@ -35,12 +35,13 @@
       "P4-LINK": "the privacy policy"
     },
     "BTN-WITH-GOOGLE": "With Google",
+    "BTN-WITH-GOOGLE-SIGN-UP": "Sign up With Google",
     "BTN-WITH-MICROSOFT": "With Microsoft",
     "HERO": {
-      "TITLE": "Karibu Elewa Conversational Learning!",
-      "DESCRIPTION": "Elewa LMS is worldst first Conversational Learning Manager.",
-      "LEARN-MORE": "Learn more on",
-      "LEARN-MORE-LINK": "https://elewa.education"
+      "TITLE": "World's first LMS designed for conversational learning.",
+      "DESCRIPTION": "Lorem ipsum dolor sit amet, consectetur adipisicing elit. Non sunt maxime, aliquam consectetur unde est corrupti dolor perferendis ab quisquam! Rerum ex magnam quam aspernatur delectus quidem ad atque quod!Lorem ipsum dolor sit amet consectetur, adipisicing elit. Itaque assumenda in non officiis id nostrum possimus quas dicta vitae nam, necessitatibus consequuntur labore perspiciatis quae, suscipit velit! Sequi, neque illum.",
+      "LEARN-MORE": "Learn more about the project on",
+      "LEARN-MORE-LINK": "https://github.com/italanta/italanta-apps"
     }
   },
   "TOS": {
@@ -50,6 +51,7 @@
     "P4-LINK": "the privacy policy"
   },
   "BTN-WITH-GOOGLE": "With Google",
+  "BTN-WITH-GOOGLE-SIGN-UP": "Sign up With Google",
   "BTN-WITH-MICROSOFT": "With Microsoft",
   "HERO": {
     "TITLE": "Karibu Elewa Conversational Learning!",

--- a/libs/features/app/auth/login/src/lib/components/register/register.component.html
+++ b/libs/features/app/auth/login/src/lib/components/register/register.component.html
@@ -8,9 +8,8 @@
             </mat-form-field>
             <mat-form-field id="name-input" data-intercom-tooltip="Name Input" class="special-input"  fxFlex="45">
                 <input matInput name="lastName" type="text" formControlName="lastName" required placeholder="{{ 'LOGIN.CREATE-ACC-FORM.FLD-LNAME' | transloco }}">
-                <mat-error>{{ 'OGIN.CREATE-ACC-FORM.FLD-NAME-REQ' | transloco }}</mat-error>
+                <mat-error>{{ 'LOGIN.CREATE-ACC-FORM.FLD-NAME-REQ' | transloco }}</mat-error>
             </mat-form-field>
-
         </div>
 
         <div fxLayout="row" fxLayoutAlign="start center">
@@ -35,17 +34,6 @@
             </mat-form-field>
         </div>
 
-        <div fxLayout="row" fxLayoutAlign="center center" fxLayoutGap="8px">
-            <mat-checkbox id="terms-input" data-intercom-tooltip="Terms Input" formControlName="acceptConditions" class="small-txt">
-            </mat-checkbox>
-            <div class="small-txt">
-                {{ "LOGIN.TOS.P1" | transloco }}
-                <a href="{{ getTermsLink() }}" target="_blank">{{ "LOGIN.TOS.P2-LINK" | transloco}}</a> {{ "LOGIN.TOS.P3" | transloco}}
-                <a href="{{ getPolicyLink() }}" target="_blank">{{ "LOGIN.TOS.P4-LINK" | transloco}}</a>.
-            </div>
-
-        </div>
-
         <div fxLayoutAlign="center none">
             <app-spinner *ngIf="isLoading" [diameter]="25"></app-spinner>
 
@@ -54,28 +42,16 @@
           </button>
         </div>
 
-        <div class="hr-with-text" fxFlex="row" fxLayoutAlign="start center">
-            {{ 'LOGIN.OR' | transloco }}
-        </div>
+        <div fxLayout="row" fxLayoutAlign="start stretch">
+            <!-- <div class="icon-box google-icon mat-elevation-z2" fxLayoutAlign="center center"> -->
+                
+                <button mat-raised-button id="googleBtn" class="uppercase-txt" (click)="loginGoogle()" fxFlex>
+                    <i class="fab fa-google white-icon"></i>
+                    {{ "LOGIN.BTN-WITH-GOOGLE-SIGN-UP" | transloco }}
+                </button>
+            <!-- </div> -->
 
-        <div fxLayout="row" fxLayoutAlign="center">
-            <div class="icon-box fb-icon mat-elevation-z2" fxLayoutAlign="start center">
-                <i class="fab fa-microsoft"></i>
-            </div>
-
-            <button mat-raised-button id="msBtn" class="uppercase-txt" (click)="loginMicrosoft()" fxFlex>
-            {{ "LOGIN.BTN-WITH-MICROSOFT" | transloco }}
-          </button>
-        </div>
-
-        <div fxLayout="row" fxLayoutAlign="center">
-            <div class="icon-box google-icon mat-elevation-z2" fxLayoutAlign="start center">
-                <i class="fab fa-google"></i>
-            </div>
-
-            <button mat-raised-button id="googleBtn" class="uppercase-txt" (click)="loginGoogle()" fxFlex>
-            {{ "LOGIN.BTN-WITH-GOOGLE" | transloco }}
-          </button>
+            
         </div>
 
     </form>

--- a/libs/features/app/auth/login/src/lib/components/register/register.component.scss
+++ b/libs/features/app/auth/login/src/lib/components/register/register.component.scss
@@ -3,6 +3,7 @@ $primary-color: #ffc200;
 $secondary-elements-color: white;
 .uppercase-txt {
     text-transform: uppercase;
+    color: $secondary-elements-color;
 }
 
 #googleBtn {
@@ -91,4 +92,10 @@ input {
 .form-body {
     align-self: center;
     width: 80%;
+}
+
+.white-icon {
+    color: $secondary-elements-color;
+    margin-right: 10px;
+    font-size: 20px;
 }

--- a/libs/features/app/auth/login/src/lib/pages/auth/auth.page.component.scss
+++ b/libs/features/app/auth/login/src/lib/pages/auth/auth.page.component.scss
@@ -11,6 +11,10 @@ $secondary-elements-color: white;
     min-height: 100%;
 }
 
+.login-form {
+    margin-top: -150px;
+}
+
 .form {
     padding: 30px;
 }


### PR DESCRIPTION
# Description

Enhancing the sign up and log in pages to have the form on the left side and text content/description on the right. This component was already created it only needed some styling and enhancements. 

To achieve this, I needed to:
- Add the needed text to the `en.json`
- Delete and refactor some commented code lines
- Adding more styling on the scss file of the component

Fixes # (issue  https://github.com/italanta/elewa/issues/130) 

## Type of change
- [ ] Enhancement (working on the styling to achieve the given design)

# Screenshot (optional)
Desktop View
![elewa](https://user-images.githubusercontent.com/79839603/225007360-675e67d5-7ac8-40d2-bb8d-e9347819ab53.png)


# How Has This Been Tested?
Step 1: Added the enhancement styling to register.component.scss
Step 2: Started the server by running ```nx serve```

# Checklist:t
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules