### PR TITLE
🎨 Move End Block to Block List #355

### DIFF
--- a/apps/conv-learning-manager/src/assets/i18n/en.json
+++ b/apps/conv-learning-manager/src/assets/i18n/en.json
@@ -89,7 +89,8 @@
         "KEYWORD-JUMP": "Keyword Jump",
         "WEBHOOK": "Webhook",
         "FAILBLOCK": "Fail Block",
-        "JUMP":"Jump"
+        "JUMP":"Jump",
+        "END-BLOCK":"End Block"
       },
       "PLACEHOLDER": {
         "ANCHOR": "Start here",

--- a/libs/features/convs-mgr/stories/blocks/library/anchor-block/src/lib/components/end-anchor/end-anchor.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/anchor-block/src/lib/components/end-anchor/end-anchor.component.html
@@ -1,1 +1,1 @@
-<div [id]="endAnchorId" class="anchor"> {{'PAGE-CONTENT.BLOCK.PLACEHOLDER.END-ANCHOR' | transloco}}</div>
+<div [id]="id" class="anchor"> {{'PAGE-CONTENT.BLOCK.PLACEHOLDER.END-ANCHOR' | transloco}}</div>

--- a/libs/features/convs-mgr/stories/blocks/library/anchor-block/src/lib/components/end-anchor/end-anchor.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/anchor-block/src/lib/components/end-anchor/end-anchor.component.ts
@@ -35,7 +35,7 @@ export class EndAnchorComponent implements OnInit {
 
   private _decorateInput()
   {
-    let input = document.getElementById(this.endAnchorId) as Element;
+    let input = document.getElementById(this.id) as Element;
     if (this.jsPlumb)
     {
       input = _JsPlumbTargetLeftComponentDecorator(input, this.jsPlumb);

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/icons-and-titles.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/icons-and-titles.ts
@@ -107,12 +107,8 @@ export const iconsAndTitles: any = {
     title: 'PAGE-CONTENT.BLOCK.TITLES.KEYWORD-JUMP',
     icon: 'fas fa-bullseye',
   },
-  30: {
-    title: 'PAGE-CONTENT.BLOCK.TITLES.END-BLOCK',
-    icon: 'fas fa-stop'
-  },
   9999: {
-    title: '',
-    icon: '',
+    title: 'PAGE-CONTENT.BLOCK.TITLES.END-BLOCK',
+    icon: 'fas fa-stop',
   },
 };

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/icons-and-titles.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/icons-and-titles.ts
@@ -107,6 +107,10 @@ export const iconsAndTitles: any = {
     title: 'PAGE-CONTENT.BLOCK.TITLES.KEYWORD-JUMP',
     icon: 'fas fa-bullseye',
   },
+  30: {
+    title: 'PAGE-CONTENT.BLOCK.TITLES.END-BLOCK',
+    icon: 'fas fa-clock'
+  },
   9999: {
     title: '',
     icon: '',

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/icons-and-titles.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/icons-and-titles.ts
@@ -109,7 +109,7 @@ export const iconsAndTitles: any = {
   },
   30: {
     title: 'PAGE-CONTENT.BLOCK.TITLES.END-BLOCK',
-    icon: 'fas fa-clock'
+    icon: 'fas fa-stop'
   },
   9999: {
     title: '',

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
@@ -12,7 +12,7 @@ import {
   TextMessageBlock, EmailMessageBlock, PhoneMessageBlock, DocumentMessageBlock, StickerMessageBlock,
   VoiceMessageBlock, VideoMessageBlock, ListMessageBlock, JumpBlock, MultipleInputMessageBlock, FailBlock, 
   ImageInputBlock, LocationInputBlock, AudioInputBlock, VideoInputBlock, WebhookBlock, OpenEndedQuestionBlock,
-  KeywordMessageBlock, MultiContentInputBlock
+  KeywordMessageBlock, MultiContentInputBlock, EndStoryAnchorBlock
 } from '@app/model/convs-mgr/stories/blocks/messaging';
 
 import { StoryEditorFrame } from '../../model/story-editor-frame.model';
@@ -37,6 +37,7 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
   blockTemplates: StoryBlock[] = [
     { id: 'input-message-block', type: StoryBlockTypes.TextMessage, message: 'Message', blockIcon: this.getBlockIcon(StoryBlockTypes.TextMessage) } as TextMessageBlock,
     // { id: 'io-questions-block', type: StoryBlockTypes.Input, message: 'Input', blockIcon: this.getBlockIcon(StoryBlockTypes.Input) } as QuestionMessageBlock,
+    { id: 'end-anchor-block', type:StoryBlockTypes.EndStoryAnchorBlock, message: 'End Story', blockIcon:this.getBlockIcon(StoryBlockTypes.EndStoryAnchorBlock)} as EndStoryAnchorBlock,
     // { id: 'io-block', type: StoryBlockTypes.IO, message: 'IO', blockIcon: this.getBlockIcon(StoryBlockTypes.IO) } as QuestionMessageBlock,
     { id: 'input-location-block', type: StoryBlockTypes.Location, message: 'Location', blockIcon: this.getBlockIcon(StoryBlockTypes.Location) } as LocationMessageBlock,
     { id: 'input-image-block', type: StoryBlockTypes.Image, message: 'Image', blockIcon: this.getBlockIcon(StoryBlockTypes.Image) } as ImageMessageBlock,
@@ -62,7 +63,8 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
     { id: 'webhook-block' , type: StoryBlockTypes.WebhookBlock, message: 'Webhook', blockIcon:this.getBlockIcon(StoryBlockTypes.WebhookBlock) } as WebhookBlock,
     { id: 'open-ended-question-block', type:StoryBlockTypes.OpenEndedQuestion, message: 'Open Ended Question', blockIcon:this.getBlockIcon(StoryBlockTypes.OpenEndedQuestion) } as OpenEndedQuestionBlock,
     { id: 'multi-content-input' , type:StoryBlockTypes.MultiContentInput, message:'Multi Content Input', blockIcon:this.getBlockIcon(StoryBlockTypes.MultiContentInput) } as MultiContentInputBlock,
-    { id: 'keyword-jump-block', type:StoryBlockTypes.keyword, message: 'Keyword Jump', blockIcon:this.getBlockIcon(StoryBlockTypes.keyword) } as KeywordMessageBlock
+    { id: 'keyword-jump-block', type:StoryBlockTypes.keyword, message: 'Keyword Jump', blockIcon:this.getBlockIcon(StoryBlockTypes.keyword) } as KeywordMessageBlock,
+    { id: 'end-anchor-block', type:StoryBlockTypes.EndStoryAnchorBlock, message: 'End Story', blockIcon:this.getBlockIcon(StoryBlockTypes.EndStoryAnchorBlock)} as EndStoryAnchorBlock
   ];
   blockTemplate$: Observable<StoryBlock[]> = of(this.blockTemplates);
   constructor(private _logger: Logger) { }
@@ -75,6 +77,9 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
   }
   addBlock(type: number) {
     switch (type) {
+      case StoryBlockTypes.EndStoryAnchorBlock:
+        this.frame.newBlock(StoryBlockTypes.EndStoryAnchorBlock); 
+        break;
       case StoryBlockTypes.TextMessage:
         this.frame.newBlock(StoryBlockTypes.TextMessage);
         break;

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
@@ -37,7 +37,7 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
   blockTemplates: StoryBlock[] = [
     { id: 'input-message-block', type: StoryBlockTypes.TextMessage, message: 'Message', blockIcon: this.getBlockIcon(StoryBlockTypes.TextMessage) } as TextMessageBlock,
     // { id: 'io-questions-block', type: StoryBlockTypes.Input, message: 'Input', blockIcon: this.getBlockIcon(StoryBlockTypes.Input) } as QuestionMessageBlock,
-    { id: 'end-anchor-block', type:StoryBlockTypes.EndStoryAnchorBlock, message: 'End Story', blockIcon:this.getBlockIcon(StoryBlockTypes.EndStoryAnchorBlock)} as EndStoryAnchorBlock,
+    { id: 'story-end-anchor', type:StoryBlockTypes.EndStoryAnchorBlock, message: 'End Story', blockIcon:this.getBlockIcon(StoryBlockTypes.EndStoryAnchorBlock)} as EndStoryAnchorBlock,
     // { id: 'io-block', type: StoryBlockTypes.IO, message: 'IO', blockIcon: this.getBlockIcon(StoryBlockTypes.IO) } as QuestionMessageBlock,
     { id: 'input-location-block', type: StoryBlockTypes.Location, message: 'Location', blockIcon: this.getBlockIcon(StoryBlockTypes.Location) } as LocationMessageBlock,
     { id: 'input-image-block', type: StoryBlockTypes.Image, message: 'Image', blockIcon: this.getBlockIcon(StoryBlockTypes.Image) } as ImageMessageBlock,


### PR DESCRIPTION
# Description

Adding the end block to the block list so that I can easily find it and use it when building conversational flows.
I have put it on the second position so it is easy to spot


Fixes #355 

## Type of change

- [x] New feature (non-breaking change which adds functionality)


# Screenshot (optional)
![EndStoryIcon](https://user-images.githubusercontent.com/109944021/227878062-a000e6c3-5713-4a18-ad8d-93aba0711205.png)

[Screencast from 27-03-23 11:32:48.webm](https://user-images.githubusercontent.com/109944021/227893261-aa432c3a-5a2d-486f-a83d-01f2cef913a5.webm)



# How Has This Been Tested?
On clicking the end block on the block list, it shows up in the editor frame.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

