### PR TITLE
🔀 🤖 🧱 Enable bot engine to handle keyword jump block

### DIFF
--- a/libs/functions/bot-engine/main/src/lib/services/match-input/match-input.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/match-input/match-input.service.ts
@@ -21,5 +21,8 @@ export class MatchInputService {
         return this.matchStrategy.matchId(id, options)
     }
 
+    matchText(text: string, options: any[]){
+        return this.matchStrategy.matchText(text, options)
+    }
 
 }

--- a/libs/functions/bot-engine/main/src/lib/services/match-input/match-strategy.interface.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/match-input/match-strategy.interface.ts
@@ -1,4 +1,5 @@
 export interface MatchStrategy {
     match : (message: string, options: any[]) => number
     matchId : (id: string, options: any[]) => number
+    matchText : (text: string, options: any[]) => number
 }

--- a/libs/functions/bot-engine/main/src/lib/services/match-input/strategies/exact-match.strategy.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/match-input/strategies/exact-match.strategy.ts
@@ -15,4 +15,10 @@ export class ExactMatch implements MatchStrategy {
 
     return optionIndex;
   }
+
+  matchText(text: string, options: any[]) {
+    const optionIndex: number = __findIndex(options, (o) => o.message.toLowerCase() == text.toLowerCase());
+
+    return optionIndex;
+  }
 }

--- a/libs/functions/bot-engine/main/src/lib/services/process-message/process-message.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/process-message/process-message.service.ts
@@ -123,7 +123,7 @@ export class ProcessMessageService
   {
     const processOperationBlock = new OperationBlockFactory(this._blockService$, this._connService$, this._tools).resolve(nextBlock.type);
 
-    const updatedPosition = await processOperationBlock.handleBlock(nextBlock, newCursor, orgId, endUserId);
+    const updatedPosition = await processOperationBlock.handleBlock(nextBlock, newCursor, orgId, endUserId, msg);
 
     const sideOperations = processOperationBlock.sideOperations;
 

--- a/libs/functions/bot-engine/main/src/lib/services/process-operation-block/block-type/end-story-block.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/process-operation-block/block-type/end-story-block.service.ts
@@ -26,7 +26,7 @@ export class EndStoryBlockService implements IProcessOperationBlock
    *  3. Update the cursor
    *  4. Resolve and return the success block
    */
-  async handleBlock(storyBlock: EndStoryAnchorBlock, currentCursor: Cursor, orgId: string, currentStory: string, endUserId?: string)
+  async handleBlock(storyBlock: EndStoryAnchorBlock, currentCursor: Cursor, orgId: string, endUserId: string)
   {
     const cursor = currentCursor;
 

--- a/libs/functions/bot-engine/main/src/lib/services/process-operation-block/block-type/keyword-jump.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/process-operation-block/block-type/keyword-jump.service.ts
@@ -33,7 +33,7 @@ export class KeywordJumpBlockService extends MultipleOptionsMessageService imple
 
 	public async handleBlock(storyBlock: WebhookBlock, updatedCursor: Cursor, orgId: string, endUserId: string, message: Message)
 	{
-		const newCursor = await this.getNextBlock(message, updatedCursor, storyBlock, orgId, updatedCursor.position.storyId, endUserId);
+		const newCursor = await this.getNextBlock(message, updatedCursor, storyBlock, orgId, updatedCursor.position.storyId, endUserId, "matchText");
 
 		const nextBlock = await this.blockDataService.getBlockById(newCursor.position.blockId, orgId, newCursor.position.storyId);
 

--- a/libs/functions/bot-engine/main/src/lib/services/process-operation-block/block-type/keyword-jump.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/process-operation-block/block-type/keyword-jump.service.ts
@@ -1,0 +1,48 @@
+import { HandlerTools } from "@iote/cqrs";
+
+import { Cursor } from "@app/model/convs-mgr/conversations/admin/system";
+
+import { WebhookBlock } from "@app/model/convs-mgr/stories/blocks/messaging";
+import { Message } from "@app/model/convs-mgr/conversations/messages";
+
+import { BlockDataService } from "../../data-services/blocks.service";
+import { ConnectionsDataService } from "../../data-services/connections.service";
+
+import { IProcessOperationBlock } from "../models/process-operation-block.interface";
+
+import { MultipleOptionsMessageService } from "../../next-block/block-type/multiple-options-block.service";
+/**
+ * When an end user send a message to the bot, we need to know the type of block @see {StoryBlockTypes} we sent 
+ *  so that we can process the response based on that block.
+ * 
+ * This service processes a location input from the user.
+ * 
+ */
+export class KeywordJumpBlockService extends MultipleOptionsMessageService implements IProcessOperationBlock
+{
+	sideOperations: Promise<any>[] = [];
+	tools: HandlerTools;
+	blockDataService: BlockDataService;
+
+	constructor(blockDataService: BlockDataService, connDataService: ConnectionsDataService, tools: HandlerTools)
+	{
+		super(blockDataService, connDataService, tools);
+		this.tools = tools;
+		this.blockDataService = blockDataService;
+	}
+
+	public async handleBlock(storyBlock: WebhookBlock, updatedCursor: Cursor, orgId: string, endUserId: string, message: Message)
+	{
+		const newCursor = await this.getNextBlock(message, updatedCursor, storyBlock, orgId, updatedCursor.position.storyId, endUserId);
+
+		const nextBlock = await this.blockDataService.getBlockById(newCursor.position.blockId, orgId, newCursor.position.storyId);
+
+		return {
+			storyBlock: nextBlock,
+			newCursor
+		};
+	}
+	
+
+
+}

--- a/libs/functions/bot-engine/main/src/lib/services/process-operation-block/models/process-operation-block.interface.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/process-operation-block/models/process-operation-block.interface.ts
@@ -1,7 +1,8 @@
 import { Cursor } from "@app/model/convs-mgr/conversations/admin/system";
+import { Message } from "@app/model/convs-mgr/conversations/messages";
 import { StoryBlock } from "@app/model/convs-mgr/stories/blocks/main";
 
 export interface IProcessOperationBlock {
   sideOperations: Promise<any>[];
-  handleBlock(storyBlock: StoryBlock, updatedCursor: Cursor, orgId: string, endUserId: string)
+  handleBlock(storyBlock: StoryBlock, updatedCursor: Cursor, orgId: string, endUserId: string, message?: Message)
 }

--- a/libs/model/convs-mgr/stories/blocks/main/src/lib/story-block-types.enum.ts
+++ b/libs/model/convs-mgr/stories/blocks/main/src/lib/story-block-types.enum.ts
@@ -168,6 +168,8 @@ export function isOperationBlock(blockType: StoryBlockTypes)
       return true;
     case StoryBlockTypes.WebhookBlock:
       return true;
+    case StoryBlockTypes.keyword:
+      return true;
     default:
       return false;
   }


### PR DESCRIPTION
# Description

A keyword jump block enables organisations/clm users to direct users to a specific flow in relation to their text input. It can be used for things such as COUPON CODES i.e. depending on a given coupon code entered they can be directed to a specific flow.