### PR TITLE
🔀 ✨ 🤖 Implement marking a single unit of conversation as complete

### DIFF
--- a/libs/functions/bot-engine/main/src/lib/services/data-services/end-user.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/data-services/end-user.service.ts
@@ -66,4 +66,20 @@ import { throws } from 'assert';
     };
     await this.createDocument(newStatus, this._docPath, endUser.id);
   }
+
+  /**
+   *  Updates the end-user's conversation status to complete
+   */
+  async setConversationComplete(endUserId: string, value: number)
+  {
+    const endUser = await this.getDocumentById(endUserId, this._docPath);
+    const isConversationComplete = value;
+
+    const newStatus: EndUser = {
+      ...endUser,
+      isConversationComplete
+    };
+
+    await this.updateDocument(newStatus, this._docPath, endUser.id);
+  }
 }

--- a/libs/functions/bot-engine/whatsapp/src/lib/models/whatsapp-active-channel.model.ts
+++ b/libs/functions/bot-engine/whatsapp/src/lib/models/whatsapp-active-channel.model.ts
@@ -8,7 +8,7 @@ import { extension } from "mime-types";
 import { HandlerTools } from "@iote/cqrs";
 import { __DECODE_AES } from "@app/elements/base/security-config";
 
-import { ActiveChannel } from "@app/functions/bot-engine";
+import { ActiveChannel, EndUserDataService } from "@app/functions/bot-engine";
 
 import { MetaMessagingProducts, RecepientType, WhatsAppMessageType, WhatsAppOutgoingMessage, WhatsAppTemplateMessage, WhatsappTemplateParameter } from "@app/model/convs-mgr/functions";
 import { WhatsAppCommunicationChannel } from '@app/model/convs-mgr/conversations/admin/system';
@@ -37,10 +37,12 @@ import { StandardMessageOutgoingMessageParser } from "../io/outgoing-message-par
 export class WhatsappActiveChannel implements ActiveChannel
 {
   channel: WhatsAppCommunicationChannel;
+  endUserService: EndUserDataService;
 
   constructor(private _tools: HandlerTools, channel: WhatsAppCommunicationChannel)
   {
     this.channel = channel;
+    this.endUserService = new EndUserDataService(_tools, channel.orgId);
   }
 
   parseOutMessage(storyBlock: StoryBlock, phone: string)
@@ -102,6 +104,16 @@ export class WhatsappActiveChannel implements ActiveChannel
     ).then(response =>
     {
       this._tools.Logger.log(() => `[SendWhatsAppMessageModel].sendMessage: Success in sending message ${JSON.stringify(response.data)}`);
+
+      // Mark the conversation as complete
+      this.endUserService.setConversationComplete(`w_${this.channel.n}_${whatsappMessage.to}`, +1).then(() => {
+
+        this._tools.Logger.log(() => `[SendWhatsAppMessageModel].sendMessage: Conversation marked as complete`);
+      }).catch(err => {
+        this._tools.Logger.log(() => `[SendWhatsAppMessageModel].sendMessage: Error in updating isComplete`);
+      }
+      );
+
     }).catch(error =>
     {
       if (error.response) {

--- a/libs/functions/bot-engine/whatsapp/src/lib/whats-app-receive-message.handler.ts
+++ b/libs/functions/bot-engine/whatsapp/src/lib/whats-app-receive-message.handler.ts
@@ -87,6 +87,11 @@ export class WhatsAppReceiveIncomingMsgHandler extends FunctionHandler<IncomingW
 
     const message = whatsappIncomingMessageParser.parse(sanitizedResponse.message);
 
+    // STEP 6: Update the isComplete flag
+    //         We need to update the isComplete flag to -1 so that the user can continue the conversation
+    //         We do this here because we have successfully received the message
+    await this._setConversationComplete(communicationChannel.orgId, communicationChannel.n, message.endUserPhoneNumber, tools);
+
     // Don't process the message if we cannot parse it
     if (!message) return { status: 500, message: `Failed to parse incoming message: ${sanitizedResponse.message}` } as RestResult;
     
@@ -101,4 +106,18 @@ export class WhatsAppReceiveIncomingMsgHandler extends FunctionHandler<IncomingW
   {
     return Object.keys(data).length === 0;
   }
+
+  /**
+   * Method which updates the isComplete flag to -1 so that the user can continue the conversation
+   * @param {string} orgId - The organization id
+   * @param {number} n - The channel number
+   * @param {string} phoneNumber - The phone number of the user
+   * */
+  private _setConversationComplete(orgId: string, n: number, phoneNumber: string, tools: HandlerTools)
+  {
+    const _endUserService$ = new EndUserDataService(tools, orgId);
+
+    return _endUserService$.setConversationComplete(generateEndUserId(phoneNumber, PlatformType.WhatsApp, n), -1);
+  }
 }
+

--- a/libs/model/convs-mgr/conversations/chats/src/lib/end-user.interface.ts
+++ b/libs/model/convs-mgr/conversations/chats/src/lib/end-user.interface.ts
@@ -9,16 +9,18 @@ import { IObject } from "@iote/bricks";
 export interface EndUser extends IObject
 {
     /** The name of the end user chatting with our bot */
-    name?               : string;
+    name?                          : string;
 
     /** The phone number of the end user chatting with our bot */
-    phoneNumber         : string;
+    phoneNumber                    : string;
 
     /** The current status of the ongoing chat between the end user and our chatbot */
-    status              : ChatStatus;
+    status                         : ChatStatus;
 
     /** The story that the end user is currently responding to */
-    currentStory       ?: string;
+    currentStory                  ?: string;
+
+    isConversationComplete        ?: number;
 }
 
 /**


### PR DESCRIPTION
# Description

Implement marking a single unit of conversation as complete on the end user document. We set -1 when the user sends us  the message and mark +1 when a message is successfully sent to the end user.