### PR TITLE
💾 🎵 Save Audio Input Block Result As a Variable #405

### DIFF
--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/audio-input-block-edit/audio-input-block-edit.component.html
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/audio-input-block-edit/audio-input-block-edit.component.html
@@ -3,4 +3,11 @@
     <span class="title">{{ title | transloco }}</span>
     <input class="text" id="message" name="message" formControlName="message" />
   </form>
+
+  <div class="validation-check">
+    <label class="label" for="setValidation">{{ "PAGE-CONTENT.BLOCK.VALIDATORS.SET-VALIDATION-CHECKBOX" | transloco }}</label>
+    <input class="checkbox" type="checkbox" [checked]="validate" (change)="setValidation()" name="setValidation" id="">
+  </div>
+
+  <app-variable-input [BlockFormGroup]="form" [validate]="validate"></app-variable-input>
 </div>

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/audio-input-block-edit/audio-input-block-edit.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/audio-input-block-edit/audio-input-block-edit.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
 @Component({
@@ -6,7 +6,16 @@ import { FormGroup } from '@angular/forms';
   templateUrl: './audio-input-block-edit.component.html',
   styleUrls: ['./audio-input-block-edit.component.scss'],
 })
-export class AudioInputBlockEditComponent {
+export class AudioInputBlockEditComponent implements OnInit {
   @Input() form: FormGroup;
   @Input() title: string;
+  validate: boolean;
+
+  ngOnInit() {
+    this.validate = this.form.value.variable.validate;
+  }
+  
+  setValidation() {
+    this.validate = !this.validate;
+  }
 }

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/variable-input/variable-input.component.html
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/variable-input/variable-input.component.html
@@ -6,6 +6,10 @@
       <div *ngSwitchCase="nametype">
         <app-name-validations [variablesForm]="variablesForm" [validate]="validate"></app-name-validations>
       </div>
+      
+      <div *ngSwitchCase="audiotype">
+        <app-name-validations [variablesForm]="variablesForm" [validate]="validate"></app-name-validations>
+      </div>
 
       <div class="variable-defaults">
         <div class="variables_name">

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/variable-input/variable-input.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/variable-input/variable-input.component.ts
@@ -32,6 +32,7 @@ export class VariableInputComponent implements OnInit, OnDestroy {
   ];
 
   nametype = StoryBlockTypes.Name;
+  audiotype = StoryBlockTypes.AudioInput;
   emailtype = StoryBlockTypes.Email;
   phonetype = StoryBlockTypes.PhoneNumber;
 


### PR DESCRIPTION
# Description
This PR adds the ability to save the audio variable in the user's response and also a validation form.

Fixes #405 

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# Screenshot:
![audio](https://user-images.githubusercontent.com/104300169/231668037-9be2edef-751e-4c2c-8401-8e44c7e5f74e.png)

**Test Configuration**: (optional)
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
