### PR TITLE
💾 📧 Save Email Input Block Result As a Variable

### DIFF
--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/email-block-edit/email-block-edit.component.html
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/email-block-edit/email-block-edit.component.html
@@ -5,5 +5,10 @@
       formControlName="message" />
   </form>
 
-  <app-variable-input [BlockFormGroup]="form"></app-variable-input>
+  <div class="validation-check">
+    <label class="label" for="setValidation">{{ "PAGE-CONTENT.BLOCK.VALIDATORS.SET-VALIDATION-CHECKBOX" | transloco }}</label>
+    <input class="checkbox" type="checkbox" [checked]="validate" (change)="setValidation()" name="setValidation" id="">
+  </div>
+
+  <app-variable-input [BlockFormGroup]="form" [validate]="validate"></app-variable-input>
 </div>

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/email-block-edit/email-block-edit.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/email-block-edit/email-block-edit.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
 @Component({
@@ -6,7 +6,17 @@ import { FormGroup } from '@angular/forms';
   templateUrl: './email-block-edit.component.html',
   styleUrls: ['./email-block-edit.component.scss'],
 })
-export class EmailBlockEditComponent {
+export class EmailBlockEditComponent implements OnInit {
   @Input() form: FormGroup;
   @Input() title: string;
+  validate: boolean;
+
+  ngOnInit() {
+    this.validate = this.form.value.variable.validate;
+}
+
+  setValidation(){
+    this.validate = !this.validate;
+  }
+
 }

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/email-block-form.model.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/email-block-form.model.ts
@@ -17,11 +17,13 @@ export function _CreateEmailMessageBlockForm(_fb: FormBuilder, blockData: EmailM
     type: [blockData.type ?? StoryBlockTypes.Email],
     position: [blockData.position ?? { x: 200, y: 50 }],
 
+    // variables FormGroup
     variable: _fb.group({
       name: [blockData.variable?.name ?? '', [Validators.required]],
       type: [blockData.variable?.type ?? 1, [Validators.required]],
       validate: [blockData.variable?.validate ?? false, [Validators.required]],
 
+      // validators FormGroup
       validators: _fb.group({
         regex: [blockData.variable?.validators?.regex ?? ''],
         validationMessage: [

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/email-block-form.model.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/email-block-form.model.ts
@@ -1,4 +1,4 @@
-import { FormBuilder, FormGroup } from "@angular/forms";
+import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 
 import { StoryBlockTypes } from "@app/model/convs-mgr/stories/blocks/main";
 import { EmailMessageBlock } from "@app/model/convs-mgr/stories/blocks/messaging";
@@ -15,6 +15,20 @@ export function _CreateEmailMessageBlockForm(_fb: FormBuilder, blockData: EmailM
     defaultTarget: [blockData.defaultTarget ?? ''],
     message: [blockData?.message! ?? ''],
     type: [blockData.type ?? StoryBlockTypes.Email],
-    position: [blockData.position ?? { x: 200, y: 50 }]
+    position: [blockData.position ?? { x: 200, y: 50 }],
+
+    variable: _fb.group({
+      name: [blockData.variable?.name ?? '', [Validators.required]],
+      type: [blockData.variable?.type ?? 1, [Validators.required]],
+      validate: [blockData.variable?.validate ?? false, [Validators.required]],
+
+      validators: _fb.group({
+        regex: [blockData.variable?.validators?.regex ?? ''],
+        validationMessage: [
+          blockData.variable?.validators?.validationMessage ??
+            "Invalid email, could you try again, please?",
+        ],
+      })
+    })
   })
 }

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/email-validations/email-validations.component.html
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/email-validations/email-validations.component.html
@@ -1,1 +1,18 @@
-<p>email-validations works!</p>
+<div [formGroup]="variablesForm">
+    <div class="validation-section" formGroupName="variable">
+      <div class="validation-wrapper" *ngIf="validate" formGroupName="validators">
+        <div class="validation_regex">
+          <label class="label" for="regex">{{"PAGE-CONTENT.BLOCK.VALIDATORS.REGEX" | transloco }}</label>
+          <input class="input" type="text" formControlName="regex" id="regex"
+            [placeholder]="'PAGE-CONTENT.BLOCK.VALIDATORS.PLACEHOLDER-REGEX' | transloco">
+        </div>
+
+        <div class="validation_message">
+            <label class="label" for="validationMessage">{{ "PAGE-CONTENT.BLOCK.VALIDATORS.ERROR-MESSAGE" | transloco
+              }}</label>
+            <textarea class="text-area" name="validationMessage" id="validationMessage" formControlName="validationMessage"
+              cols="30" rows="5"></textarea>
+          </div>
+      </div>
+    </div>
+  </div>

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/email-validations/email-validations.component.html
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/email-validations/email-validations.component.html
@@ -1,0 +1,1 @@
+<p>email-validations works!</p>

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/email-validations/email-validations.component.scss
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/email-validations/email-validations.component.scss
@@ -1,0 +1,27 @@
+.validation_regex {
+    display: grid;
+    grid-template-rows: 1fr 2fr;
+    gap: 5px;
+  }
+  .label {
+      font-weight: 400;
+      font-size: 0.8rem;
+    }
+    
+    .input {
+      outline: none;
+      border-radius: 5px;
+      border: none;
+      padding: 0.5rem;
+      min-width: 5rem;
+      width: auto;
+    }
+    
+    .validation-wrapper {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      background-color: #e8eaec;
+      padding: 0.5rem;
+      border-radius: 5px;
+    }

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/email-validations/email-validations.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/email-validations/email-validations.component.ts
@@ -1,8 +1,12 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
+import { FormGroup } from '@angular/forms';
 
 @Component({
   selector: 'app-email-validations',
   templateUrl: './email-validations.component.html',
   styleUrls: ['./email-validations.component.scss'],
 })
-export class EmailValidationsComponent {}
+export class EmailValidationsComponent {
+  @Input() validate: boolean;
+  @Input() variablesForm: FormGroup;
+}

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/email-validations/email-validations.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/email-validations/email-validations.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-email-validations',
+  templateUrl: './email-validations.component.html',
+  styleUrls: ['./email-validations.component.scss'],
+})
+export class EmailValidationsComponent {}

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/variable-input/variable-input.component.html
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/variable-input/variable-input.component.html
@@ -7,6 +7,10 @@
         <app-name-validations [variablesForm]="variablesForm" [validate]="validate"></app-name-validations>
       </div>
 
+      <div *ngSwitchCase="emailtype">
+        <app-email-validations [variablesForm]="variablesForm" [validate]="validate"></app-email-validations>
+      </div>
+
       <div class="variable-defaults">
         <div class="variables_name">
           <label class="label" for="name">{{ "PAGE-CONTENT.BLOCK.VALIDATORS.VARIABLE-INFO" | transloco }}</label>

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/variable-input/variable-input.component.html
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/variable-input/variable-input.component.html
@@ -28,7 +28,7 @@
 
         <div class="variables_type">
           <label class="label" for="type">type</label>
-          <select class="select" formControlName="type" id="type" required>...ib/convs-mgr-process-inputs.module.ts
+          <select class="select" formControlName="type" id="type" required>
             <option class="option" *ngFor="let type of variablesTypesList; let i=index" [value]="type.value">
               {{ type.name }}
             </option>

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/convs-mgr-process-inputs.module.ts
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/convs-mgr-process-inputs.module.ts
@@ -6,10 +6,15 @@ import { MultiLangModule } from '@ngfi/multi-lang';
 
 import { VariableInputComponent } from './components/variable-input/variable-input.component';
 import { NameValidationsComponent } from './components/name-validations/name-validations.component';
+import { EmailValidationsComponent } from './components/email-validations/email-validations.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, MultiLangModule],
-  declarations: [VariableInputComponent, NameValidationsComponent],
+  declarations: [
+    VariableInputComponent,
+    NameValidationsComponent,
+    EmailValidationsComponent,
+  ],
   exports: [VariableInputComponent],
 })
 export class ConvsMgrProcessInputsModule {}


### PR DESCRIPTION
# Description

Process user responses on the email block as a variable, regex and add a validation message that will be shown to the user if it doesn't match.

Fixes # (issue) -  Fixes #394 Save Email Input Block Result As a Variable
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# Screenshot (optional)

https://user-images.githubusercontent.com/69570282/231961652-54514c24-4124-48f0-b6a4-8eb85f0d9440.mp4




# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
