### PR TITLE
:toolbox:  Add Hover Tooltip to Delete Icon of Connections #428

### DIFF
--- a/libs/features/convs-mgr/stories/editor/src/lib/providers/manage-jsPlumb-connections.function.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/providers/manage-jsPlumb-connections.function.ts
@@ -13,6 +13,9 @@ export function CreateDeleteButton() {
   deleteButton.id = "overlay-delete-button";
   // deleteButton.classList.add("overlay-button ");
 
+    // Set the title attribute to provide guidance on how to delete a connection
+    deleteButton.title = "Double click";
+
   // Return the created button
   return deleteButton
 }


### PR DESCRIPTION
# Description

 Add a hover tooltip to the delete icon of connections
 Set the tooltip text to "double click"

Fixes #428

## Type of change
- [x] New feature (non-breaking change which adds functionality)


# Screenshot (optional)

[Screencast from 24-04-23 13:39:50.webm](https://user-images.githubusercontent.com/109944021/233979531-a194fd95-cfa6-4395-9da4-d96a2ec3c85e.webm)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

