### PR TITLE
🔀 🤖  Fix message templates not working

### DIFF
--- a/libs/functions/bot-engine/main/src/index.ts
+++ b/libs/functions/bot-engine/main/src/index.ts
@@ -18,3 +18,4 @@ export * from 'libs/functions/bot-engine/main/src/lib/utils/generateUserId';
 export * from 'libs/functions/bot-engine/main/src/lib/io/incoming-message-parsers/models/incoming-message-parser.interface'
 export * from './lib/handlers/talk-to-operator.handler';
 export * from './lib/handlers/move-chat.handler';
+export * from './lib/services/variable-injection/mail-merge-variables.service';

--- a/libs/functions/bot-engine/main/src/lib/handlers/send-outgoing-message.handler.ts
+++ b/libs/functions/bot-engine/main/src/lib/handlers/send-outgoing-message.handler.ts
@@ -8,6 +8,7 @@ import { CommunicationChannel, PlatformType } from '@app/model/convs-mgr/convers
 import { Message, MessageDirection } from '@app/model/convs-mgr/conversations/messages';
 
 import { ActiveChannelFactory } from '../factories/active-channel/active-channel.factory';
+import { __DateFromStorage } from '@iote/time';
 
 /**
  * @Description : When an end user sends a message to the chatbot from a thirdparty application, this function is triggered, 
@@ -78,7 +79,7 @@ export class SendOutgoingMsgHandler extends FunctionHandler<Message, RestResult>
       const latestMessage = await msgService.getLatestUserMessage(endUserId, this._orgId);
 
       // Get the date in milliseconds
-      const latestMessageTime = new Date(latestMessage ? latestMessage.createdOn : 0).getTime();
+      const latestMessageTime = __DateFromStorage(latestMessage.createdOn).unix() * 1000;
 
       // Check if the last message sent was more than 24hours ago
       if ((Date.now() - latestMessageTime) > 86400000) {

--- a/libs/functions/bot-engine/main/src/lib/handlers/send-outgoing-message.handler.ts
+++ b/libs/functions/bot-engine/main/src/lib/handlers/send-outgoing-message.handler.ts
@@ -75,7 +75,7 @@ export class SendOutgoingMsgHandler extends FunctionHandler<Message, RestResult>
       
       const endUserId = generateEndUserId(outgoingPayload.endUserPhoneNumber, PlatformType.WhatsApp, n);
 
-      const latestMessage = await msgService.getLatestMessage(endUserId, this._orgId);
+      const latestMessage = await msgService.getLatestUserMessage(endUserId, this._orgId);
 
       // Get the date in milliseconds
       const latestMessageTime = new Date(latestMessage ? latestMessage.createdOn : 0).getTime();

--- a/libs/functions/bot-engine/main/src/lib/io/outgoing-message.parser.ts
+++ b/libs/functions/bot-engine/main/src/lib/io/outgoing-message.parser.ts
@@ -1,5 +1,6 @@
-import { Message, MessageTemplateConfig, OutgoingMessagePayload } from "@app/model/convs-mgr/conversations/messages";
+import { Message, MessageTemplateConfig, OutgoingMessagePayload, TemplateMessageParams } from "@app/model/convs-mgr/conversations/messages";
 import { StoryBlock, StoryBlockTypes } from "@app/model/convs-mgr/stories/blocks/main";
+import { HandlerTools } from "@iote/cqrs";
 
 /**
  * Our chatbot can send different types of messages, be it a text message, a location, an image, ...
@@ -27,7 +28,7 @@ export abstract class OutgoingMessageParser
 
   abstract getListBlockParserOut     (storyBlock: StoryBlock, phone: string): any
 
-  abstract getMessageTemplateParserOut (templateConfig: MessageTemplateConfig, phone: string, message: Message): any
+  abstract getMessageTemplateParserOut (templateConfig: MessageTemplateConfig, params: TemplateMessageParams[], phone: string, message: Message): any
 
   // abstract getStickerBlockParserOut  (storyBlock: StoryBlock, phone: string): Message
 
@@ -69,7 +70,7 @@ export abstract class OutgoingMessageParser
     return parser(storyBlock, phone);
   }
 
-  parseOutMessageTemplate(templateConfig: MessageTemplateConfig, phone: string, message: Message) {
-    return this.getMessageTemplateParserOut(templateConfig, phone, message);
+  parseOutMessageTemplate(templateConfig: MessageTemplateConfig, params: TemplateMessageParams[], phone: string, message: Message) {
+    return this.getMessageTemplateParserOut(templateConfig, params, phone, message);
   }
 }

--- a/libs/functions/bot-engine/main/src/lib/model/active-channel.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/model/active-channel.service.ts
@@ -1,5 +1,5 @@
 import { CommunicationChannel } from "@app/model/convs-mgr/conversations/admin/system";
-import { Message, MessageTemplateConfig, OutgoingMessagePayload } from "@app/model/convs-mgr/conversations/messages";
+import { Message, MessageTemplateConfig, OutgoingMessagePayload, TemplateMessageParams } from "@app/model/convs-mgr/conversations/messages";
 import { StoryBlock } from "@app/model/convs-mgr/stories/blocks/main";
 
 /**
@@ -40,9 +40,9 @@ export interface ActiveChannel
    *                      with the chatbot
    * 
    */
-  send(msg: OutgoingMessagePayload);
+  send(msg: OutgoingMessagePayload, standardMessage?: Message);
 
   getMediaFile(mediaId: string, mime_type: string);
 
-  parseOutMessageTemplate(templateConfig: MessageTemplateConfig, phoneNumber: string, message: Message);
+  parseOutMessageTemplate(templateConfig: MessageTemplateConfig, params: TemplateMessageParams[], phoneNumber: string, message: Message);
 }

--- a/libs/functions/bot-engine/main/src/lib/services/data-services/messages.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/data-services/messages.service.ts
@@ -1,6 +1,6 @@
 import { HandlerTools } from '@iote/cqrs';
 
-import { Message } from '@app/model/convs-mgr/conversations/messages';
+import { Message, MessageDirection } from '@app/model/convs-mgr/conversations/messages';
 
 import { BotDataService } from './data-service-abstract.class';
 
@@ -39,5 +39,23 @@ export class MessagesDataService extends BotDataService<Message> {
     const latestMessage = await this.getLatestDocument(this._docPath);
 
     return latestMessage[0];
+  }
+
+  async getLatestUserMessage(endUserId: string, orgId: string): Promise<Message> {
+    this._docPath = `orgs/${orgId}/end-users/${endUserId}/messages`
+
+    const latestMessage = await this.getDocuments(this._docPath);
+
+    // Filter out the messages that are not from the user
+    const userMessages = latestMessage.filter(msg => 
+       (msg.direction === MessageDirection.FROM_ENDUSER_TO_AGENT ||
+        msg.direction === MessageDirection.FROM_END_USER_TO_CHATBOT));
+
+    // Return the latest message using createdOn timestamp
+    const latestUserMessage = userMessages.reduce((prev, current) => {
+      return (prev.createdOn > current.createdOn) ? prev : current
+    });
+
+    return latestUserMessage;
   }
 }

--- a/libs/functions/bot-engine/main/src/lib/services/variable-injection/mail-merge-variables.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/variable-injection/mail-merge-variables.service.ts
@@ -77,4 +77,12 @@ export class MailMergeVariables
 
     return variableValues;
   }
+
+  async getSingleVariableValue(orgId: string, endUserId: string, variableName: string) {
+    const variableRepo = this._tools.getRepository<any>(`orgs/${orgId}/end-users/${endUserId}/variables`);
+
+    const variableValues = await variableRepo.getDocumentById(`values`);
+
+    return variableValues[variableName];
+  }
 }

--- a/libs/functions/bot-engine/whatsapp/src/lib/io/outgoing-message-parser/whatsapp-api-outgoing-message-parser.class.ts
+++ b/libs/functions/bot-engine/whatsapp/src/lib/io/outgoing-message-parser/whatsapp-api-outgoing-message-parser.class.ts
@@ -1,10 +1,10 @@
-import { StoryBlock } from '@app/model/convs-mgr/stories/blocks/main';
+import { OutgoingMessageParser } from '@app/functions/bot-engine';
 
+import { StoryBlock } from '@app/model/convs-mgr/stories/blocks/main';
 import
 {
   ActionButtonsInfo,
   ActionInfo,
-  ActionSectionInfo,
   ActionSectionInfoRow,
   InteractiveButtonMessage,
   InteractiveListMessage,
@@ -23,9 +23,7 @@ import
 } from '@app/model/convs-mgr/functions';
 
 import { DocumentMessageBlock, ImageMessageBlock, QuestionMessageBlock, TextMessageBlock, VideoMessageBlock, VoiceMessageBlock } from '@app/model/convs-mgr/stories/blocks/messaging';
-
-import { OutgoingMessageParser } from '@app/functions/bot-engine';
-import { Message, MessageTemplateConfig } from '@app/model/convs-mgr/conversations/messages';
+import { Message, MessageTemplateConfig, TemplateMessageParams } from '@app/model/convs-mgr/conversations/messages';
 
 /**
  * Interprets messages received from whatsapp and converts them to a Message
@@ -274,11 +272,11 @@ export class WhatsappOutgoingMessageParser extends OutgoingMessageParser
   }
 
 
-  getMessageTemplateParserOut(templateConfig: MessageTemplateConfig, phone: string, message: Message)
+  getMessageTemplateParserOut(templateConfig: MessageTemplateConfig, params: TemplateMessageParams[], phone: string, message: Message)
   {
     let messageTemplate: WhatsAppTemplateMessage;
 
-    let { name, languageCode, params } = templateConfig;
+    let { name, languageCode } = templateConfig;
 
     // Create the message template payload which will be sent to whatsapp
     messageTemplate = {
@@ -291,21 +289,15 @@ export class WhatsappOutgoingMessageParser extends OutgoingMessageParser
         language: {
           code: languageCode,
         },
-
       }
     };
-
-    // Set the params if they exist
-    if(message && message.params) {
-      params = message.params.map((param) => param.value);
-    }
 
     if(params) {
       const templateParams: WhatsappTemplateParameter[] = params.map((param) =>
       {
         return {
           type: WhatsAppMessageType.TEXT,
-          text: param,
+          text: param.value,
         };
       });
 
@@ -321,6 +313,9 @@ export class WhatsappOutgoingMessageParser extends OutgoingMessageParser
 
     return messageTemplate;
   }
+
+
+
   // getStickerBlockParserOut(storyBlock: StoryBlock, phone: string) {
   //   // TODO: 
   //   let link: string;

--- a/libs/functions/bot-engine/whatsapp/src/lib/io/outgoing-message-parser/whatsapp-api-outgoing-message-parser.class.ts
+++ b/libs/functions/bot-engine/whatsapp/src/lib/io/outgoing-message-parser/whatsapp-api-outgoing-message-parser.class.ts
@@ -15,6 +15,7 @@ import
   WhatsAppImageMessage,
   WhatsAppInteractiveMessage,
   WhatsAppMessageType,
+  WhatsappTemplateComponent,
   WhatsAppTemplateMessage,
   WhatsappTemplateParameter,
   WhatsAppTextMessage,
@@ -275,22 +276,12 @@ export class WhatsappOutgoingMessageParser extends OutgoingMessageParser
 
   getMessageTemplateParserOut(templateConfig: MessageTemplateConfig, phone: string, message: Message)
   {
+    let messageTemplate: WhatsAppTemplateMessage;
+
     let { name, languageCode, params } = templateConfig;
 
-    if(message && message.params) {
-      params = message.params.map((param) => param.value);
-    }
-
-    const templateParams: WhatsappTemplateParameter[] = params.map((param) =>
-    {
-      return {
-        type: WhatsAppMessageType.TEXT,
-        text: param,
-      };
-    });
-
     // Create the message template payload which will be sent to whatsapp
-    const messageTemplate: WhatsAppTemplateMessage = {
+    messageTemplate = {
       messaging_product: MetaMessagingProducts.WHATSAPP,
       recepient_type: RecepientType.INDIVIDUAL,
       to: phone,
@@ -300,14 +291,33 @@ export class WhatsappOutgoingMessageParser extends OutgoingMessageParser
         language: {
           code: languageCode,
         },
-        components: [
-          {
-            type: "body",
-            parameters: templateParams,
-          }
-        ]
+
       }
     };
+
+    // Set the params if they exist
+    if(message && message.params) {
+      params = message.params.map((param) => param.value);
+    }
+
+    if(params) {
+      const templateParams: WhatsappTemplateParameter[] = params.map((param) =>
+      {
+        return {
+          type: WhatsAppMessageType.TEXT,
+          text: param,
+        };
+      });
+
+      const templateComponents = [
+        {
+          type: "body",
+          parameters: templateParams,
+        }
+      ] as WhatsappTemplateComponent[];
+
+      messageTemplate.template.components = templateComponents;
+    }
 
     return messageTemplate;
   }

--- a/libs/functions/bot-engine/whatsapp/src/lib/models/whatsapp-active-channel.model.ts
+++ b/libs/functions/bot-engine/whatsapp/src/lib/models/whatsapp-active-channel.model.ts
@@ -5,19 +5,18 @@ import { createWriteStream } from "fs";
 import { join } from 'path';
 import { extension } from "mime-types";
 
+import { __DateFromStorage } from "@iote/time";
 import { HandlerTools } from "@iote/cqrs";
 import { __DECODE_AES } from "@app/elements/base/security-config";
+import { ActiveChannel, EndUserDataService, MailMergeVariables, MessagesDataService, generateEndUserId } from "@app/functions/bot-engine";
 
-import { ActiveChannel, EndUserDataService } from "@app/functions/bot-engine";
-
-import { MetaMessagingProducts, RecepientType, WhatsAppMessageType, WhatsAppOutgoingMessage, WhatsAppTemplateMessage, WhatsappTemplateParameter } from "@app/model/convs-mgr/functions";
-import { WhatsAppCommunicationChannel } from '@app/model/convs-mgr/conversations/admin/system';
+import { WhatsAppOutgoingMessage } from "@app/model/convs-mgr/functions";
+import { PlatformType, WhatsAppCommunicationChannel } from '@app/model/convs-mgr/conversations/admin/system';
 import { StoryBlock } from "@app/model/convs-mgr/stories/blocks/main";
-import { Message, MessageTemplateConfig } from "@app/model/convs-mgr/conversations/messages";
+import { Message, MessageTemplateConfig, TemplateMessageParams } from "@app/model/convs-mgr/conversations/messages";
 
 import { WhatsappOutgoingMessageParser } from "../io/outgoing-message-parser/whatsapp-api-outgoing-message-parser.class";
 import { StandardMessageOutgoingMessageParser } from "../io/outgoing-message-parser/standardized-message-to-outgoing-message.parser";
-
 
 /**
  * After the bot engine processes the incoming message and returns the next block,
@@ -59,17 +58,79 @@ export class WhatsappActiveChannel implements ActiveChannel
     return outgoingMessagePayload;
   }
 
-  parseOutMessageTemplate(templateConfig: MessageTemplateConfig, phone: string, message: Message)
+  parseOutMessageTemplate(templateConfig: MessageTemplateConfig, params: TemplateMessageParams[], phone: string, message: Message)
   {
     // Create the message template payload which will be sent to whatsapp
     const messageTemplate = new WhatsappOutgoingMessageParser()
-                              .getMessageTemplateParserOut(templateConfig, phone, message);
+                              .getMessageTemplateParserOut(templateConfig, params, phone, message);
 
     return messageTemplate;
   }
 
-  async send(whatsappMessage: WhatsAppOutgoingMessage)
+  private async _handle24hourWindow(phone: string, message: Message)
   {
+    const msgService = new MessagesDataService(this._tools);
+    const n = this.channel.n;
+    const orgId = this.channel.orgId;
+    const endUserId = generateEndUserId(phone, PlatformType.WhatsApp, n);
+
+    const latestMessage = await msgService.getLatestUserMessage(endUserId, orgId);
+
+    if (latestMessage) {
+      // Get the date in milliseconds
+      const latestMessageTime = __DateFromStorage(latestMessage.createdOn as Date);
+
+      if ((Date.now() - latestMessageTime.unix() * 1000) > 864000) {
+
+        this._tools.Logger.log(() => `[SendOutgoingMsgHandler].execute - Whatsapp 24 hours limit has passed`);
+        this._tools.Logger.log(() => `[SendOutgoingMsgHandler].execute - Sending opt-in message to ${phone}`);
+
+        const templateConfig = this.channel.templateConfig;
+
+        if (templateConfig) {
+          let params = message.params || templateConfig.params || null;
+
+          if(params) params = await this.__resolveParamVariables(params, orgId, endUserId);
+
+          // Get the message template
+          return this.parseOutMessageTemplate(templateConfig, params, phone, message);
+        } else {
+          this._tools.Logger.warn(() => `[SendOutgoingMsgHandler].execute [Warning] - Missing Template Config! Message may fail to reach user`);
+          return null;
+        }
+      }
+    }
+  }
+
+  private __getValueFromVariable(orgId: string, endUserId: string, variable: string) {
+    const variablesService = new MailMergeVariables(this._tools);
+
+    return variablesService.getSingleVariableValue(orgId, endUserId, variable)
+  }
+
+  private async __resolveParamVariables(params: TemplateMessageParams[], orgId: string, endUserId: string) { 
+    const resolvedParams = params.map(async (param) => {
+
+      if(param.value === '_var_') {
+        const value = await this.__getValueFromVariable(orgId, endUserId, param.name);
+
+        return { 
+          name: param.name,
+          value
+        } as TemplateMessageParams
+      } else {
+        return param
+      }
+    });
+
+    return Promise.all(resolvedParams);
+  }
+
+  async send(whatsappMessage: WhatsAppOutgoingMessage, standardMessage?: Message)
+  {
+    if(standardMessage) {
+      whatsappMessage = await this._handle24hourWindow(whatsappMessage.to, standardMessage) || whatsappMessage;
+    }
     // STEP 1: Assign the access token and the business phone number id
     //            required by the whatsapp api to send messages
     const ACCESS_TOKEN = this.channel.accessToken;

--- a/libs/functions/bot-engine/whatsapp/src/lib/whatsapp-send-message.handler.ts
+++ b/libs/functions/bot-engine/whatsapp/src/lib/whatsapp-send-message.handler.ts
@@ -90,7 +90,7 @@ export class WhatsAppSendOutgoingMsgHandler extends FunctionHandler<any, RestRes
 
         // Get the opt-in message template
         outgoingMessagePayload = new WhatsappOutgoingMessageParser()
-                                  .parseOutMessageTemplate(templateConfig, outgoingPayload.endUserPhoneNumber, outgoingPayload);
+                                  .parseOutMessageTemplate(templateConfig, templateConfig.params, outgoingPayload.endUserPhoneNumber, outgoingPayload);
       }
 
       // STEP 6: Send the message

--- a/libs/model/convs-mgr/conversations/messages/src/index.ts
+++ b/libs/model/convs-mgr/conversations/messages/src/index.ts
@@ -3,3 +3,4 @@ export * from './lib/message.interface';
 export * from './lib/payload-in.interface';
 export * from './lib/payload-out.interface';
 export * from './lib/message-template-config.interface';
+export * from './lib/message-params.interface';

--- a/libs/model/convs-mgr/conversations/messages/src/lib/message-params.interface.ts
+++ b/libs/model/convs-mgr/conversations/messages/src/lib/message-params.interface.ts
@@ -1,5 +1,5 @@
-export interface MessageParams 
+export interface TemplateMessageParams 
 {
-  name                : string;
-  value               : string;
+  name: string;
+  value: string | '_var_';
 }

--- a/libs/model/convs-mgr/conversations/messages/src/lib/message-template-config.interface.ts
+++ b/libs/model/convs-mgr/conversations/messages/src/lib/message-template-config.interface.ts
@@ -1,3 +1,5 @@
+import { TemplateMessageParams } from "./message-params.interface";
+
 /** This interface represents the message template configuration 
  *   which can be used to opt-in users to the chatbot
  */
@@ -14,5 +16,5 @@ export interface MessageTemplateConfig
    *  then the final message will be 'Hello John, how are you?'
    * 
   */
-  params: string[];
+  params: TemplateMessageParams[];
 }

--- a/libs/model/convs-mgr/conversations/messages/src/lib/message.interface.ts
+++ b/libs/model/convs-mgr/conversations/messages/src/lib/message.interface.ts
@@ -4,7 +4,7 @@ import { MessageTypes } from "@app/model/convs-mgr/functions";
 import { Location } from "@app/model/convs-mgr/stories/blocks/messaging";
 
 import { IncomingMessagePayload } from "./payload-in.interface";
-import { MessageParams } from "./message-params.interface";
+import { TemplateMessageParams } from "./message-params.interface";
 
 /** 
  * Our chatbot recieves different types of messages, be it a text message, a location, an image, ...
@@ -46,7 +46,7 @@ export interface Message extends IObject
 
   url?                : string;
 
-  params?             : MessageParams[];
+  params?             : TemplateMessageParams[];
 }
 
 

--- a/libs/model/convs-mgr/functions/src/lib/whatsapp/whatsapp-template-message.interface.ts
+++ b/libs/model/convs-mgr/functions/src/lib/whatsapp/whatsapp-template-message.interface.ts
@@ -14,7 +14,7 @@ export interface WhatsAppTemplateMessage extends WhatsAppOutgoingMessage
     language: {
       code: string;
     },
-    components: WhatsappTemplateComponent[];
+    components?: WhatsappTemplateComponent[];
   };
 
 }


### PR DESCRIPTION
# Description

This pull request fixes the issue with sending message templates among some improvements on the same. The time conversation failed and return NaN.

The params passed from the Message object are given a priority over the ones on the template Config in the channel. But if neither is included, the template message is sent without params