### PR TITLE
:floppy_disk: Save Image Input Block Result As a Variable #441

### DIFF
--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/image-input-block-edit/image-input-block-edit.component.html
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/image-input-block-edit/image-input-block-edit.component.html
@@ -3,4 +3,7 @@
     <span class="title">{{ title | transloco }}</span>
     <input class="text" id="message" name="message" formControlName="message" />
   </form>
+
+  <app-variable-input [BlockFormGroup]="form"></app-variable-input>
+  
 </div>

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/image-input-block-form.model.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/image-input-block-form.model.ts
@@ -1,4 +1,4 @@
-import { FormBuilder, FormGroup } from "@angular/forms";
+import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 
 import { StoryBlockTypes } from "@app/model/convs-mgr/stories/blocks/main";
 import { ImageInputBlock } from "@app/model/convs-mgr/stories/blocks/messaging";
@@ -16,6 +16,12 @@ export function _CreateImageInputBlockForm(_fb: FormBuilder, blockData: ImageInp
     defaultTarget: [blockData.defaultTarget ?? ''],
     message: [blockData?.message! ?? ''],
     type: [blockData.type ?? StoryBlockTypes.ImageInput],
-    position: [blockData.position ?? { x: 200, y: 50 }]
+    position: [blockData.position ?? { x: 200, y: 50 }], 
+
+    variable: _fb.group({
+      name: [blockData.variable?.name ?? '', [Validators.required]],
+      type: [blockData.variable?.type ?? 1, [Validators.required]]
+    })
+    
   })
 }

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/variable-input/variable-input.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/variable-input/variable-input.component.ts
@@ -9,6 +9,7 @@ import { StoryBlockTypes,StoryBlockVariable } from '@app/model/convs-mgr/stories
 import { VariableTypes } from '@app/model/convs-mgr/stories/blocks/main';
 
 import { ProcessInputService } from '../../providers/process-input.service';
+import { StoryBlockConnectionsStateModule } from '@app/state/convs-mgr/stories/block-connections';
 
 @Component({
   selector: 'app-variable-input',
@@ -36,6 +37,7 @@ export class VariableInputComponent implements OnInit, OnDestroy {
   emailtype = StoryBlockTypes.Email;
   phonetype = StoryBlockTypes.PhoneNumber;
   locationtype = StoryBlockTypes.LocationInputBlock
+  imagetype = StoryBlockTypes.ImageInput
 
   constructor(private _processInputSer: ProcessInputService) {}
 


### PR DESCRIPTION
# Description
As an org, we should be able to save image responses as variables. 
After a user is prompted for an image, the result should be saved as a variable of type string

Fixes #441

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


# Screenshot (optional)
[Screencast from 02-05-23 09:47:54.webm](https://user-images.githubusercontent.com/109944021/235599662-1c67bd49-80fb-4a6b-af57-583db9e0c010.webm)



# How Has This Been Tested?
I have the expected behavior as shown in the uploaded screencast.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

