### PR TITLE
:recycle: fix: persist block variables state.

### DIFF
--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/variable-input/variable-input.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/variable-input/variable-input.component.ts
@@ -5,7 +5,7 @@ import { cloneDeep as __cloneDeep } from 'lodash';
 import { map, switchMap } from 'rxjs';
 import { SubSink } from 'subsink';
 
-import { StoryBlockTypes,StoryBlockVariable } from '@app/model/convs-mgr/stories/blocks/main';
+import { StoryBlockTypes, StoryBlockVariable } from '@app/model/convs-mgr/stories/blocks/main';
 import { VariableTypes } from '@app/model/convs-mgr/stories/blocks/main';
 
 import { ProcessInputService } from '../../providers/process-input.service';
@@ -35,7 +35,7 @@ export class VariableInputComponent implements OnInit, OnDestroy {
   audiotype = StoryBlockTypes.AudioInput;
   emailtype = StoryBlockTypes.Email;
   phonetype = StoryBlockTypes.PhoneNumber;
-  locationtype = StoryBlockTypes.LocationInputBlock
+  locationtype = StoryBlockTypes.LocationInputBlock;
 
   constructor(private _processInputSer: ProcessInputService) {}
 
@@ -43,7 +43,10 @@ export class VariableInputComponent implements OnInit, OnDestroy {
     this.blockId = this.BlockFormGroup.value.id;
     this.blockType = this.BlockFormGroup.value.type;
 
-    // we create a copy of the formGroup so we can validate before setting the values on submit
+    /**
+     * * we create a copy of the formGroup so we can validate before setting the values on submit.
+     * * using the blocksFormGroup creates a very rare race condition where two variables can exist with the same name (if the user is warned that the variable is alredy used but still doesn't change the value) this is why we clone.
+     */ 
     this.variablesForm = __cloneDeep(this.BlockFormGroup);
     this.validateForm();
   }
@@ -79,20 +82,30 @@ export class VariableInputComponent implements OnInit, OnDestroy {
   }
 
   /**
-   * - Updates the BlockFormGroup with the selected validation type and input value type.
+   * - Updates the BlockFormGroup with all the selected properties.
    * - If validate is false, the variable validators will be reset to null.
-   * - The `type` property of the variable will be converted to an integer.
    */
   onSubmit() {
-    this.BlockFormGroup = this.variablesForm;
-    this.BlockFormGroup.controls['variable'].value.validate = this.validate;
+    // Patch variable values from the cloned variablesFrom to the BlocksFromGroup
+    const form = this.BlockFormGroup.get('variable') as FormGroup;
+    const name = this.variablesForm.get('variable.name')?.value;
+    const type = this.variablesForm.get('variable.type')?.value;
 
-    if (!this.validate) {
+    form.patchValue({ name, type: parseInt(type), validate: this.validate });
+
+    // patch validators values to BlockFormGroup validators.
+    const blockValidators = this.BlockFormGroup.get('variable.validators') as FormGroup;
+
+    if (this.validate) {
+      const regex = (this.variablesForm.get('variable.validators') as FormGroup).get('regex')?.value;
+      const max = (this.variablesForm.get('variable.validators') as FormGroup).get('max')?.value;
+      const min = (this.variablesForm.get('variable.validators') as FormGroup).get('min')?.value;
+      const validationMessage = (this.variablesForm.get('variable.validators') as FormGroup).get('validationMessage')?.value;
+
+      blockValidators.patchValue({ regex, max, min, validationMessage });
+    } else {
       this.BlockFormGroup.get('variable.validators')?.reset();
     }
-
-    const type = this.variablesForm.get('variable.type')?.value;
-    this.BlockFormGroup.controls['variable'].value.type = parseInt(type);
   }
 
   ngOnDestroy(): void {


### PR DESCRIPTION
# Issue
At the moment a block's FormGroup is updated with all the values after submission but our state does not track that, This is because we use a cloned form group to collect the values, and validate whether it's not used before we set it to the blocks form group. The issue is how we set it, we equate our blocksFormGroup to the cloned version which is not watched by our state.  

# Description
We Solve the issue but patching the values to our existing BlocksFormGroup instead of equating our FormGroup to our cloned version.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
