### PR TITLE
#444 save open ended question block result as a variable

### DIFF
--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
@@ -1,6 +1,7 @@
 <div class="form-wrapper">
   <form [formGroup]="form" action="" class="form-edit">
     <span class="title">{{ title | transloco }}</span>
-    <textarea class="text" id="message" name="message" formControlName="message" rows="3"></textarea>
+    <input class="text" id="message" name="message" formControlName="message" rows="3"/>
   </form>
+  <app-variable-input [BlockFormGroup]="form"></app-variable-input>
 </div>

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
@@ -1,7 +1,9 @@
 <div class="form-wrapper">
   <form [formGroup]="form" action="" class="form-edit">
     <span class="title">{{ title | transloco }}</span>
-    <input class="text" id="message" name="message" formControlName="message" rows="3"/>
+    <textarea class="text" id="message" name="message" formControlName="message" rows="3"></textarea>
   </form>
+
   <app-variable-input [BlockFormGroup]="form"></app-variable-input>
+  
 </div>

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/open-ended-question-block-form.model.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/open-ended-question-block-form.model.ts
@@ -1,4 +1,4 @@
-import { FormBuilder, FormGroup } from "@angular/forms";
+import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 
 import { StoryBlockTypes } from "@app/model/convs-mgr/stories/blocks/main";
 import {  OpenEndedQuestionBlock } from "@app/model/convs-mgr/stories/blocks/messaging";
@@ -15,6 +15,11 @@ export function _CreateOpenEndedQuestionBlockForm(_fb: FormBuilder, blockData: O
     message: [blockData?.message! ?? ''],
     defaultTarget: [blockData.defaultTarget ?? ''],
     type: [blockData.type ?? StoryBlockTypes.OpenEndedQuestion],
-    position: [blockData.position ?? { x: 200, y: 50 }]
+    position: [blockData.position ?? { x: 200, y: 50 }],
+
+    variable: _fb.group({
+      name: [blockData.variable?.name ?? '', [Validators.required]],
+      type: [blockData.variable?.type ?? 1, [Validators.required]]
+    })
   })
 }


### PR DESCRIPTION
# Description

This pull request Saves Open-Ended Question Block Result As a Variable

Fixes [#444](https://github.com/italanta/elewa/issues/444)

## Type of change

Please delete options that are not relevant.

- ✅ New feature (non-breaking change which adds functionality)

# Screenshot (optional)

[Screencast from 11-05-2023 10:03:40 ASUBUHI.webm](https://github.com/italanta/elewa/assets/109956415/ba65d167-bf7c-40df-8a5d-948c14e6a6c0)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- ✅ Test A
- ✅ Test B

# Checklist:

- ✅ My code follows the style guidelines of this project
- ✅ I have performed a self-review of my code
- ✅ I have commented my code, particularly in hard-to-understand areas
- ✅ I have made corresponding changes to the documentation
- ✅ My changes generate no new warnings
- ✅ I have added tests that prove my fix is effective or that my feature works
- ✅ New and existing unit tests pass locally with my changes
- ✅ Any dependent changes have been merged and published in downstream modules
