### PR TITLE
💾 📝  Save Open-Ended Question Block Result As a Variable 

### DIFF
--- a/apps/conv-learning-manager/src/assets/i18n/en.json
+++ b/apps/conv-learning-manager/src/assets/i18n/en.json
@@ -108,6 +108,7 @@
         "DOCUMENT-LINK": "Document link",
         "STICKER-LINK": "Sticker link",
         "LOCATION-INPUT": "Location Input",
+        "OPEN-ENDED-QUESTION": "Open Ended Question",
         "IMAGE-INPUT": "Image Input",
         "VIDEO-INPUT": "Video Input",
         "AUDIO-INPUT": "Audio Input",

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
@@ -3,4 +3,15 @@
     <span class="title">{{ title | transloco }}</span>
     <textarea class="text" id="message" name="message" formControlName="message" rows="3"></textarea>
   </form>
+  
+  <div class="validation-check">
+    <label for="setValidation" class="label">{{ "PAGE-CONTENT.BLOCK.VALIDATORS.SET-VALIDATION-CHECKBOX" | transloco }}</label>
+    <input type="checkbox" class="checkbox" [checked]="validate" (change)="setValidation()" name="setValidation" id="">
+  </div>
+
+  <div class="">
+
+  </div>
+
+  <app-variable-input [BlockFormGroup]="form" [validate]="validate"></app-variable-input>
 </div>

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
@@ -1,16 +1,12 @@
 <div class="form-wrapper">
   <form [formGroup]="form" action="" class="form-edit">
     <span class="title">{{ title | transloco }}</span>
-    <textarea name="message" id="message" cols="30" rows="10" [placeholder]="'PAGE-CONTENT.BLOCK.PLACEHOLDER.OPEN-ENDED-QUESTION' | transloco"></textarea>
+    <app-text-message [formgroup]="form"></app-text-message>
   </form>
   
   <div class="validation-check">
     <label for="setValidation" class="label">{{ "PAGE-CONTENT.BLOCK.VALIDATORS.SET-VALIDATION-CHECKBOX" | transloco }}</label>
     <input type="checkbox" class="checkbox" [checked]="validate" (change)="setValidation()" name="setValidation" id="">
-  </div>
-
-  <div class="">
-
   </div>
 
   <app-variable-input [BlockFormGroup]="form" [validate]="validate"></app-variable-input>

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
@@ -1,7 +1,8 @@
 <div class="form-wrapper">
   <form [formGroup]="form" action="" class="form-edit">
     <span class="title">{{ title | transloco }}</span>
-    <textarea class="text" id="message" name="message" formControlName="message" rows="3"></textarea>
+    <input class="text" id="message" name="message" [placeholder]="'PAGE-CONTENT.BLOCK.PLACEHOLDER.OPEN-ENDED-QUESTION' | transloco"
+      formControlName="message" />
   </form>
   
   <div class="validation-check">

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.html
@@ -1,8 +1,7 @@
 <div class="form-wrapper">
   <form [formGroup]="form" action="" class="form-edit">
     <span class="title">{{ title | transloco }}</span>
-    <input class="text" id="message" name="message" [placeholder]="'PAGE-CONTENT.BLOCK.PLACEHOLDER.OPEN-ENDED-QUESTION' | transloco"
-      formControlName="message" />
+    <textarea name="message" id="message" cols="30" rows="10" [placeholder]="'PAGE-CONTENT.BLOCK.PLACEHOLDER.OPEN-ENDED-QUESTION' | transloco"></textarea>
   </form>
   
   <div class="validation-check">

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/components/open-ended-question-edit/open-ended-question-edit.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
 @Component({
@@ -6,7 +6,16 @@ import { FormGroup } from '@angular/forms';
   templateUrl: './open-ended-question-edit.component.html',
   styleUrls: ['./open-ended-question-edit.component.scss'],
 })
-export class OpenEndedQuestionEditComponent {
+export class OpenEndedQuestionEditComponent implements OnInit {
   @Input() form:FormGroup;
   @Input() title: string;
+  validate: boolean;
+
+  ngOnInit() {
+    this.validate = this.form.value.variable.validate;
+  }
+
+  setValidation() {
+    this.validate = !this.validate;
+  }
 }

--- a/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/convs-mgr-edit-block-module.ts
+++ b/libs/features/convs-mgr/stories/blocks/edit/blocks-edit/src/lib/convs-mgr-edit-block-module.ts
@@ -10,6 +10,7 @@ import {
 
 import { ConvsMgrProcessInputsModule } from '@app/features/convs-mgr/stories/blocks/process-inputs';
 import { ConvsMgrBlockOptionsModule } from '@app/features/convs-mgr/stories/blocks/library/block-options';
+import { ConvsMgrReusableTextAreaModule } from '@app/features/convs-mgr/stories/blocks/library/reusable-text-area';
 
 import { QuestionButtonsEditFormsComponent } from './components/question-buttons-edit-forms/question-buttons-edit-forms.component';
 import { LocationInputBlockEditComponent } from './components/location-input-block-edit/location-input-block-edit.component';
@@ -38,6 +39,7 @@ import { ListBlockEditComponent } from './components/list-block-edit/list-block-
     MaterialDesignModule,
     ConvsMgrProcessInputsModule,
     ConvsMgrBlockOptionsModule,
+    ConvsMgrReusableTextAreaModule
   ],
   
   declarations: [

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/open-ended-question-block-form.model.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/open-ended-question-block-form.model.ts
@@ -1,4 +1,4 @@
-import { FormBuilder, FormGroup } from "@angular/forms";
+import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 
 import { StoryBlockTypes } from "@app/model/convs-mgr/stories/blocks/main";
 import {  OpenEndedQuestionBlock } from "@app/model/convs-mgr/stories/blocks/messaging";
@@ -15,6 +15,20 @@ export function _CreateOpenEndedQuestionBlockForm(_fb: FormBuilder, blockData: O
     message: [blockData?.message! ?? ''],
     defaultTarget: [blockData.defaultTarget ?? ''],
     type: [blockData.type ?? StoryBlockTypes.OpenEndedQuestion],
-    position: [blockData.position ?? { x: 200, y: 50 }]
+    position: [blockData.position ?? { x: 200, y: 50 }],
+
+    variable: _fb.group({
+      name: [blockData.variable?.name ?? '', [Validators.required]],
+      type: [blockData.variable?.type ?? 1, [Validators.required]],
+      validate: [blockData.variable?.validate ?? false, [Validators.required]],
+
+      validators: _fb.group({
+        regex: [blockData.variable?.validators?.regex ?? ''],
+        validationMessage: [
+          blockData.variable?.validators?.validationMessage ??
+            "I'm afraid I didn't get that, could you send your pin again, please?",
+        ],
+      })
+    })
   })
 }

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/open-ended-question-block-form.model.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/open-ended-question-block-form.model.ts
@@ -23,11 +23,8 @@ export function _CreateOpenEndedQuestionBlockForm(_fb: FormBuilder, blockData: O
       validate: [blockData.variable?.validate ?? false, [Validators.required]],
 
       validators: _fb.group({
-        regex: [blockData.variable?.validators?.regex ?? ''],
-        validationMessage: [
-          blockData.variable?.validators?.validationMessage ??
-            "I'm afraid I didn't get that, could you send your pin again, please?",
-        ],
+        max: [blockData.variable?.validators?.max ?? ''],
+        min: [blockData.variable?.validators?.min ?? ''],
       })
     })
   })

--- a/libs/features/convs-mgr/stories/blocks/library/open-ended-question-block/src/lib/components/open-ended-question-block/open-ended-question-block.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/open-ended-question-block/src/lib/components/open-ended-question-block/open-ended-question-block.component.html
@@ -1,7 +1,8 @@
 <div [id]="id" *ngIf="openEndedQuestionForm">
 	<form [formGroup]="openEndedQuestionForm" fxLayout="column" fxLayoutALign="start center">
-
+	
 		<app-text-message [formgroup]="openEndedQuestionForm"></app-text-message>
+		
 
 		<app-default-option-field [jsPlumb]="jsPlumb" [blockFormGroup]="openEndedQuestionForm"></app-default-option-field>
 	</form>

--- a/libs/features/convs-mgr/stories/blocks/library/open-ended-question-block/src/lib/components/open-ended-question-block/open-ended-question-block.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/open-ended-question-block/src/lib/components/open-ended-question-block/open-ended-question-block.component.ts
@@ -20,6 +20,8 @@ export class OpenEndedQuestionBlockComponent implements OnInit{
   @Input() openEndedQuestionForm: FormGroup
 
   @Input() blocksGroup: FormArray;
+
+  OpenEndedQuestionId: string;
  
   type: StoryBlockTypes;
   openQuestiontype = StoryBlockTypes.OpenEndedQuestion;
@@ -29,5 +31,7 @@ export class OpenEndedQuestionBlockComponent implements OnInit{
               private _logger: Logger) 
   { }
   
-  ngOnInit(): void {}
+  ngOnInit(): void {
+    this.OpenEndedQuestionId  = `Open_Ended_Question-${this.id}`
+  }
 }

--- a/libs/features/convs-mgr/stories/blocks/library/open-ended-question-block/src/lib/components/open-ended-question-block/open-ended-question-block.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/open-ended-question-block/src/lib/components/open-ended-question-block/open-ended-question-block.component.ts
@@ -12,7 +12,7 @@ import { _JsPlumbComponentDecorator } from '@app/features/convs-mgr/stories/bloc
   templateUrl: './open-ended-question-block.component.html',
   styleUrls: ['./open-ended-question-block.component.scss'],
 })
-export class OpenEndedQuestionBlockComponent implements OnInit{
+export class OpenEndedQuestionBlockComponent {
   @Input() id: string;
   @Input() block: OpenEndedQuestionBlock;
   @Input() jsPlumb: BrowserJsPlumbInstance;
@@ -21,8 +21,6 @@ export class OpenEndedQuestionBlockComponent implements OnInit{
 
   @Input() blocksGroup: FormArray;
 
-  OpenEndedQuestionId: string;
- 
   type: StoryBlockTypes;
   openQuestiontype = StoryBlockTypes.OpenEndedQuestion;
   blockFormGroup: FormGroup;
@@ -31,7 +29,4 @@ export class OpenEndedQuestionBlockComponent implements OnInit{
               private _logger: Logger) 
   { }
   
-  ngOnInit(): void {
-    this.OpenEndedQuestionId  = `Open_Ended_Question-${this.id}`
-  }
 }

--- a/libs/features/convs-mgr/stories/blocks/library/open-ended-question-block/src/lib/components/open-ended-question-block/open-ended-question-block.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/open-ended-question-block/src/lib/components/open-ended-question-block/open-ended-question-block.component.ts
@@ -1,11 +1,8 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { FormArray, FormBuilder, FormGroup } from '@angular/forms';
+import { Component, Input } from '@angular/core';
+import { FormGroup } from '@angular/forms';
 
-import { Logger } from '@iote/bricks-angular';
-import { StoryBlock, StoryBlockTypes } from '@app/model/convs-mgr/stories/blocks/main';
 import { OpenEndedQuestionBlock } from '@app/model/convs-mgr/stories/blocks/messaging';
 import { BrowserJsPlumbInstance } from '@jsplumb/browser-ui';
-import { _JsPlumbComponentDecorator } from '@app/features/convs-mgr/stories/blocks/library/block-options';
 
 @Component({
   selector: 'app-open-ended-question-block',
@@ -17,16 +14,6 @@ export class OpenEndedQuestionBlockComponent {
   @Input() block: OpenEndedQuestionBlock;
   @Input() jsPlumb: BrowserJsPlumbInstance;
 
-  @Input() openEndedQuestionForm: FormGroup
+  @Input() openEndedQuestionForm: FormGroup;
 
-  @Input() blocksGroup: FormArray;
-
-  type: StoryBlockTypes;
-  openQuestiontype = StoryBlockTypes.OpenEndedQuestion;
-  blockFormGroup: FormGroup;
-
-  constructor(private _fb: FormBuilder,
-              private _logger: Logger) 
-  { }
-  
 }

--- a/libs/features/convs-mgr/stories/blocks/library/open-ended-question-block/src/lib/convs-mgr-open-ended-question-block.module.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/open-ended-question-block/src/lib/convs-mgr-open-ended-question-block.module.ts
@@ -8,6 +8,7 @@ import {
   MaterialDesignModule,
 } from '@iote/bricks-angular';
 
+import { MultiLangModule } from '@ngfi/multi-lang';
 import { ConvsMgrBlockOptionsModule } from '@app/features/convs-mgr/stories/blocks/library/block-options';
 import { ConvsMgrReusableTextAreaModule } from '@app/features/convs-mgr/stories/blocks/library/reusable-text-area';
 
@@ -19,6 +20,7 @@ import { OpenEndedQuestionBlockComponent } from './components/open-ended-questio
     MaterialDesignModule,
     FlexLayoutModule,
     MaterialBricksModule,
+    MultiLangModule,
 
     FormsModule,
     ReactiveFormsModule,

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/open-ended-validations/open-ended-validations.component.html
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/open-ended-validations/open-ended-validations.component.html
@@ -1,12 +1,6 @@
 <div [formGroup]="variablesForm">
   <div class="validation-section" formGroupName="variable">
     <div class="validation-wrapper" *ngIf="validate" formGroupName="validators">
-      <div class="validation_regex">
-        <label class="label" for="regex">{{ "PAGE-CONTENT.BLOCK.VALIDATORS.REGEX" | transloco }}</label>
-        <input class="input" type="text" id="regex" formControlName="regex"
-          [placeholder]="'PAGE-CONTENT.BLOCK.VALIDATORS.PLACEHOLDER-REGEX' | transloco">
-      </div>
-
       <div class="validation_minmax">
         <div class="validation_max">
           <label class="label" for="max">{{ "PAGE-CONTENT.BLOCK.VALIDATORS.MAX" | transloco }}</label>
@@ -18,13 +12,6 @@
           <input class="input" type="number" name="min" id="min" formControlName="min"
             [placeholder]="'PAGE-CONTENT.BLOCK.VALIDATORS.PLACEHOLDER-MIN' | transloco">
         </div>
-      </div>
-
-      <div class="validation_message">
-        <label class="label" for="validationMessage">{{ "PAGE-CONTENT.BLOCK.VALIDATORS.ERROR-MESSAGE" | transloco
-          }}</label>
-        <textarea class="text-area" name="validationMessage" id="validationMessage" formControlName="validationMessage"
-          cols="30" rows="5"></textarea>
       </div>
     </div>
   </div>

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/open-ended-validations/open-ended-validations.component.html
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/open-ended-validations/open-ended-validations.component.html
@@ -1,0 +1,31 @@
+<div [formGroup]="variablesForm">
+  <div class="validation-section" formGroupName="variable">
+    <div class="validation-wrapper" *ngIf="validate" formGroupName="validators">
+      <div class="validation_regex">
+        <label class="label" for="regex">{{ "PAGE-CONTENT.BLOCK.VALIDATORS.REGEX" | transloco }}</label>
+        <input class="input" type="text" id="regex" formControlName="regex"
+          [placeholder]="'PAGE-CONTENT.BLOCK.VALIDATORS.PLACEHOLDER-REGEX' | transloco">
+      </div>
+
+      <div class="validation_minmax">
+        <div class="validation_max">
+          <label class="label" for="max">{{ "PAGE-CONTENT.BLOCK.VALIDATORS.MAX" | transloco }}</label>
+          <input class="input" type="number" name="max" id="max" formControlName="max"
+            [placeholder]="'PAGE-CONTENT.BLOCK.VALIDATORS.PLACEHOLDER-MAX' | transloco">
+        </div>
+        <div class="validation_min">
+          <label class="label" for="min">{{ "PAGE-CONTENT.BLOCK.VALIDATORS.MIN" | transloco }}</label>
+          <input class="input" type="number" name="min" id="min" formControlName="min"
+            [placeholder]="'PAGE-CONTENT.BLOCK.VALIDATORS.PLACEHOLDER-MIN' | transloco">
+        </div>
+      </div>
+
+      <div class="validation_message">
+        <label class="label" for="validationMessage">{{ "PAGE-CONTENT.BLOCK.VALIDATORS.ERROR-MESSAGE" | transloco
+          }}</label>
+        <textarea class="text-area" name="validationMessage" id="validationMessage" formControlName="validationMessage"
+          cols="30" rows="5"></textarea>
+      </div>
+    </div>
+  </div>
+</div>

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/open-ended-validations/open-ended-validations.component.scss
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/open-ended-validations/open-ended-validations.component.scss
@@ -1,0 +1,37 @@
+// global styles component-level
+.label {
+  font-weight: 400;
+  font-size: 0.8rem;
+}
+
+.input {
+  outline: none;
+  border-radius: 5px;
+  border: none;
+  padding: 0.5rem;
+  min-width: 5rem;
+  width: auto;
+}
+
+.validation-wrapper {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background-color: #e8eaec;
+  padding: 0.5rem;
+  border-radius: 5px;
+}
+
+.validation_minmax {
+  display: flex;
+  justify-content: space-between;
+  gap: 10%;
+}
+
+.validation_regex,
+.validation_max,
+.validation_min {
+  display: grid;
+  grid-template-rows: 1fr 2fr;
+  gap: 5px;
+}

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/open-ended-validations/open-ended-validations.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/open-ended-validations/open-ended-validations.component.ts
@@ -1,0 +1,12 @@
+import { Component, Input } from '@angular/core';
+import { FormGroup } from '@angular/forms';
+
+@Component({
+  selector: 'app-open-ended-validations',
+  templateUrl: './open-ended-validations.component.html',
+  styleUrls: ['./open-ended-validations.component.scss'],
+})
+export class OpenEndedValidationsComponent {
+  @Input() validate: boolean
+  @Input() variablesForm: FormGroup;
+}

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/variable-input/variable-input.component.html
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/variable-input/variable-input.component.html
@@ -19,6 +19,10 @@
         <app-location-validations [variablesForm]="variablesForm" [validate]="validate"></app-location-validations>
       </div>
 
+      <div *ngSwitchCase="OpenEndedQuestion">
+        <app-open-ended-validations [variablesForm]="variablesForm" [validate]="validate"></app-open-ended-validations>
+      </div>
+
       <div class="variable-defaults">
         <div class="variables_name">
           <label class="label" for="name">{{ "PAGE-CONTENT.BLOCK.VALIDATORS.VARIABLE-INFO" | transloco }}</label>
@@ -36,7 +40,7 @@
         </div>
       </div>
     </div>
-
+    
     <input class="btn submit-btn" [disabled]="variablesForm.invalid" type="submit" value="Apply">
   </form>
 </section>

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/variable-input/variable-input.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/components/variable-input/variable-input.component.ts
@@ -23,6 +23,7 @@ export class VariableInputComponent implements OnInit, OnDestroy {
   blockId: string;
   blockType: StoryBlockTypes;
   variablesForm: FormGroup;
+  validationForm: FormGroup;
 
   variablesTypesList = [
     { name: VariableTypes[1], value: 1 },
@@ -35,6 +36,7 @@ export class VariableInputComponent implements OnInit, OnDestroy {
   emailtype = StoryBlockTypes.Email;
   phonetype = StoryBlockTypes.PhoneNumber;
   locationtype = StoryBlockTypes.LocationInputBlock;
+  OpenEndedQuestion = StoryBlockTypes.OpenEndedQuestion
 
   constructor(private _processInputSer: ProcessInputService) {}
 

--- a/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/convs-mgr-process-inputs.module.ts
+++ b/libs/features/convs-mgr/stories/blocks/process-inputs/src/lib/convs-mgr-process-inputs.module.ts
@@ -9,6 +9,7 @@ import { NameValidationsComponent } from './components/name-validations/name-val
 import { EmailValidationsComponent } from './components/email-validations/email-validations.component';
 import { PhoneValidationsComponent } from './components/phone-validations/phone-validations.component';
 import { LocationValidationsComponent } from './components/location-validations/location-validations.component';
+import { OpenEndedValidationsComponent } from './components/open-ended-validations/open-ended-validations.component';
 
 @NgModule({
   imports: [CommonModule, ReactiveFormsModule, MultiLangModule],
@@ -18,6 +19,7 @@ import { LocationValidationsComponent } from './components/location-validations/
     EmailValidationsComponent,
     PhoneValidationsComponent,
     LocationValidationsComponent,
+    OpenEndedValidationsComponent,
   ],
   exports: [VariableInputComponent],
 })


### PR DESCRIPTION
# Description

This pull request solves issue #444 that required me to create an edit panel for open ended questions.

## Type of change


- [ ] New feature (non-breaking change which adds functionality)

# Screenshot (optional)
   
![image](https://github.com/italanta/elewa/assets/107908318/95a5fbe0-0175-4321-9d9f-21743868303d)




# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
