### PR TITLE
🔍 Add search icon to search bar and adjust width to match margins of the blocks below it #467

### DIFF
--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.html
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.html
@@ -2,7 +2,7 @@
   <div class="search" fxFlex>
     <mat-form-field class="search-input" appearance="outline">
       <input matInput placeholder="Search" (input)="filterBlocks($event)" />
-      <mat-icon matPrefix>{{ 'PAGE-CONTENT.TOP-BAR.SEARCH' | transloco }}</mat-icon>
+      <mat-icon matPrefix class="fa fa-search"></mat-icon>
     </mat-form-field>
   </div>
 

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.scss
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.scss
@@ -19,6 +19,9 @@
 	width: 5px;
   }
 
+.search-input {
+  width: 100%;
+}
 
 .search, .search input {
 	max-width: 100%;


### PR DESCRIPTION
# Description

This PR fixes the issue of styling in the search bar by adding a search icon and adjusting width to match the blocks below

Fixes #467 

## Type of change
- [ ] New feature (non-breaking change which adds functionality)

# Screenshot (optional)

![image](https://github.com/italanta/elewa/assets/26298045/faa69af8-45d1-4546-a09a-063e91a62220)

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
