### PR TITLE
As a user i should be able to update my channel details after i publish a story   3

### DIFF
--- a/apps/conv-learning-manager/src/assets/i18n/en.json
+++ b/apps/conv-learning-manager/src/assets/i18n/en.json
@@ -166,6 +166,7 @@
     "TOP-BAR": {
       "SAVE-STORY": "Save",
       "PUBLISH-STORY": "Publish Story",
+      "UPDATE-CHANNEL-DETAILS": "Update Channel Details",
       "SEARCH": "Search"
     },
     "CHANNEL": {

--- a/libs/features/convs-mgr/stories/editor/src/lib/pages/story-editor/story-editor.page.html
+++ b/libs/features/convs-mgr/stories/editor/src/lib/pages/story-editor/story-editor.page.html
@@ -57,7 +57,7 @@
           </button>
 
           <button [disabled]="!storyHasBeenSaved" (click)="addToChannel()" mat-flat-button class="add-channel-btn">
-            <span> {{'PAGE-CONTENT.TOP-BAR.PUBLISH-STORY' | transloco }} </span>
+            <span> {{ isPublished ? ('PAGE-CONTENT.TOP-BAR.UPDATE-CHANNEL-DETAILS' | transloco) : ('PAGE-CONTENT.TOP-BAR.PUBLISH-STORY' | transloco) }}</span>
           </button>
         </div>
       </div>


### PR DESCRIPTION
# Description

This feature makes it easier for a user to update details of a channel, they do not have to create a new channel everytime they want to introduce changes. 

- After a story is published the first time, the user does not have to save it again to update channel details.  
- Updates made  reflect on the db under channels/{{channelId}}.
- Fields not updated remain intact.

Fixes issue #453

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)

# Video (optional)
[update channel details.webm](https://github.com/italanta/elewa/assets/48943229/cd83b3ba-367b-4e3b-a957-629c98538f35)

# How Has This Been Tested?

- [ ] Runs on Development server

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
