### PR TITLE
:bug: fix deleted blocks connection bug when a story is not saved #424

### DIFF
--- a/libs/features/convs-mgr/stories/editor/src/lib/pages/story-editor/story-editor.page.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/pages/story-editor/story-editor.page.ts
@@ -185,7 +185,7 @@ export class StoryEditorPageComponent implements OnInit, OnDestroy {
     const connections = this.frame.getJsPlumbConnections as any[];
 
     // remove duplicate jsplumb connections
-    this.state.connections = connections.filter((con) => !con.targetId.includes('jsPlumb'));
+    this.state.connections = connections.filter((con) => !con.targetId.includes('jsPlumb') && !con.deleted);
 
     this._editorStateService.persist(this.state)
         .subscribe((success) => {

--- a/libs/features/convs-mgr/stories/editor/src/lib/pages/story-editor/story-editor.page.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/pages/story-editor/story-editor.page.ts
@@ -185,7 +185,7 @@ export class StoryEditorPageComponent implements OnInit, OnDestroy {
     const connections = this.frame.getJsPlumbConnections as any[];
 
     // remove duplicate jsplumb connections
-    this.state.connections = connections.filter((con) => !con.targetId.includes('jsPlumb') && !con.deleted);
+    this.state.connections = connections.filter((con) => !con.targetId.includes('jsPlumb'));
 
     this._editorStateService.persist(this.state)
         .subscribe((success) => {

--- a/libs/state/convs-mgr/stories/block-connections/src/lib/services/block-connections.service.ts
+++ b/libs/state/convs-mgr/stories/block-connections/src/lib/services/block-connections.service.ts
@@ -24,12 +24,12 @@ export class BlockConnectionsService implements OnDestroy {
   }
 
   deleteConnection(connection: StoryBlockConnection) {
-    return this._connections$$.remove(connection).subscribe();
+    return this._sbS.sink = this._connections$$.remove(connection).subscribe();
   }
 
 
   deleteBlockConnections(block: StoryBlock) {
-    this._connections$$.get().pipe(take(1)).subscribe((connections: StoryBlockConnection[]) => {
+    this.getAllConnections().pipe(take(1)).subscribe((connections: StoryBlockConnection[]) => {
 
       // Filter out the connections associated with the block
       const remainingConnections = connections.filter(

--- a/libs/state/convs-mgr/stories/block-connections/src/lib/services/block-connections.service.ts
+++ b/libs/state/convs-mgr/stories/block-connections/src/lib/services/block-connections.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, OnDestroy } from '@angular/core';
 
-import { Observable } from 'rxjs';
+import { Observable, take } from 'rxjs';
 
 import { StoryBlock, StoryBlockConnection } from '@app/model/convs-mgr/stories/blocks/main';
 
@@ -27,10 +27,18 @@ export class BlockConnectionsService implements OnDestroy {
     return this._connections$$.remove(connection).subscribe();
   }
 
-  deleteBlockConnections(block: StoryBlock){
-    this._connections$$.deleteBlockConnections(block);
-  }
 
+  deleteBlockConnections(block: StoryBlock) {
+    this._connections$$.get().pipe(take(1)).subscribe((connections: StoryBlockConnection[]) => {
+
+      // Filter out the connections associated with the block
+      const remainingConnections = connections.filter(
+        (connection) => connection.sourceId !== block.id && connection.targetId !== block.id
+      );
+      this._connections$$.set(remainingConnections);
+    });
+  }
+  
   ngOnDestroy(): void {
     this._sbS.unsubscribe();
   }

--- a/libs/state/convs-mgr/stories/block-connections/src/lib/stores/story-connections.store.ts
+++ b/libs/state/convs-mgr/stories/block-connections/src/lib/stores/story-connections.store.ts
@@ -9,7 +9,7 @@ import { tap, throttleTime, switchMap } from 'rxjs/operators';
 import { Logger } from '@iote/bricks-angular';
 
 import { Story } from '@app/model/convs-mgr/stories/main';
-import { StoryBlock, StoryBlockConnection } from '@app/model/convs-mgr/stories/blocks/main';
+import { StoryBlockConnection } from '@app/model/convs-mgr/stories/blocks/main';
 
 import { ActiveStoryStore } from '@app/state/convs-mgr/stories';
 
@@ -35,18 +35,5 @@ export class StoryConnectionsStore extends DataStore<StoryBlockConnection>
     this._sbS.sink = data$.subscribe(connections => {
       this.set(connections, 'UPDATE - FROM DB');
     });
-  }
-
-  deleteBlockConnections(block: StoryBlock){
-    const blockId = block.id?.toString() as string
-    let connections: StoryBlockConnection[] = []
-
-    this._sbS.add(
-      this.get().subscribe(_connections => {
-        connections = _connections.filter(conn => conn.sourceId.endsWith(blockId) || conn.targetId === blockId);
-        // Delete from store
-        this.removeMultiple(connections);
-      })
-    );
   }
 }


### PR DESCRIPTION
# Description
When a block with connection is deleted without being saved, the connections were huddling together in a strange manner instead of being deleted. 

I have updated the delete connection method to filter out connection associated with the block in state instead of looking for those connections in storage 

Fixes #424 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Screenshot (optional)

[Screencast from 18-05-23 11:06:06.webm](https://github.com/italanta/elewa/assets/109944021/eaef74fd-63c8-41b2-9597-b0146a42d30c)


# How Has This Been Tested?
Connections are deleted in state and not in storage.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

