### PR TITLE
#466 Relevant Search Results Fix

### DIFF
--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.html
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.html
@@ -9,7 +9,7 @@
   <div fxLayout="column" *ngIf="blockTemplate$ | async as blocks" fxFlex>
     <!-- message block -->
     <div class="block-list">
-      <h6 class="message-block">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MESSAGE-BLOCK' | transloco }}</h6>
+      <h6 class="message-block" *ngIf="titlefilter">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MESSAGE-BLOCK' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'messages-block'">
@@ -33,7 +33,7 @@
     </div>
     <!-- questions block -->
     <div class="block-list">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.QUESTION-BLOCKS' | transloco }}</h6>
+      <h6 *ngIf="titlefilter">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.QUESTION-BLOCKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'questions-block'">
@@ -57,7 +57,7 @@
     </div>
      <!-- Image block -->
     <div class="block-list">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.IMAGE-BLOCKS' | transloco }}</h6>
+      <h6 *ngIf="titlefilter">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.IMAGE-BLOCKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'images-block'">
@@ -81,7 +81,7 @@
     </div>
     <!-- documents block -->
     <div class="block-list">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.DOCUMENT-BLOCKS' | transloco }}</h6>
+      <h6 *ngIf="titlefilter">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.DOCUMENT-BLOCKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'documents-block'">
@@ -105,7 +105,7 @@
     </div>
      <!-- multimedia block -->
      <div class="block-list">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MULTIMEDIA-BLOCKS' | transloco }}</h6>
+      <h6 *ngIf="titlefilter">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MULTIMEDIA-BLOCKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'multimedia-block'">
@@ -129,7 +129,7 @@
     </div>
     <!-- end block -->
     <div class="block-list">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.END-BLOCK' | transloco }}</h6>
+      <h6 *ngIf="titlefilter">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.END-BLOCK' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'end-block'">
@@ -154,7 +154,7 @@
 
     <!-- bricks -->
     <div class="block-list">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.BRICKS' | transloco }}</h6>
+      <h6 *ngIf="titlefilter">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.BRICKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'bricks'">

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
@@ -34,6 +34,7 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
 
   @Input() frame: StoryEditorFrame;
   filterInput$$: BehaviorSubject<string> = new BehaviorSubject<string>('');
+  titlefilter = true;
 
   blockTemplates: StoryBlock[] = [
     { id: 'input-message-block', type: StoryBlockTypes.TextMessage, message: 'Message', blockIcon: this.getBlockIcon(StoryBlockTypes.TextMessage), blockCategory: 'messages-block' } as TextMessageBlock,
@@ -192,6 +193,7 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
   }
 
   filterBlocks(event: any) {
+    this.titlefilter = false;
     this.filterInput$$.next(event.target.value);
   }
 


### PR DESCRIPTION
# Description

This pull request fixes the bug of issue #466 . 

When you search for a specific item or element, only the results related to that specific search  are displayed and not the unrelated blocks.

Resolves #466.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshot
![Screenshot from 2023-05-19 14-22-54](https://github.com/italanta/elewa/assets/53012069/c6a64f34-00ce-4432-a3ca-0f41e8735c23)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
