### PR TITLE
:bug: :video_camera: When I select a video in the modal but opt to close the window, the video shouldn't be uploaded #486

### DIFF
--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/video-block-form.model.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/video-block-form.model.ts
@@ -16,7 +16,7 @@ import {VideoMessageBlock } from "@app/model/convs-mgr/stories/blocks/messaging"
     message: [blockData?.message! ?? ''],
     fileSrc:[blockData?.fileSrc! ?? '', Validators.required],
     fileName:[blockData?.fileName! ?? ''],
-    mediaQulaity:[blockData?.mediaQuality! ?? ''],
+    mediaQuality:[blockData?.mediaQuality! ?? ''],
     type: [blockData.type ?? StoryBlockTypes.Video],
     position: [blockData.position ?? { x: 200, y: 50 }]
   })

--- a/libs/features/convs-mgr/stories/blocks/library/video-message-block/src/lib/modals/video-upload-modal/video-upload-modal.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/video-message-block/src/lib/modals/video-upload-modal/video-upload-modal.component.html
@@ -17,7 +17,7 @@
           </div>
     
           <div class="media">
-            <input type="file" accept=".mp4" [id]="videoInputId" hidden (change)="onVideoSelected($event)" #videoInput>
+            <input type="file" accept=".mp4" [id]="videoInputId" hidden (change)="onVideoSelected($event)" >
             <label [for]="videoInputId">
               <ng-container *ngIf="!videoPath">
                 <img *ngIf="!videoPath" src="https://i.postimg.cc/zvbh3gqD/thumbnail1.png">
@@ -60,7 +60,7 @@
         </div>
       </div>
       <div class="apply">
-        <button type="submit" class="apply__button" (click)="submit()">
+        <button type="submit" class="apply__button" [disabled]="!selectedVideoFile" (click)="apply()">
           {{'PAGE-CONTENT.BLOCK.BUTTONS.VIDEO-MODAL.APPLY' | transloco}}
         </button>
       </div>

--- a/libs/features/convs-mgr/stories/blocks/library/video-message-block/src/lib/modals/video-upload-modal/video-upload-modal.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/video-message-block/src/lib/modals/video-upload-modal/video-upload-modal.component.html
@@ -17,14 +17,14 @@
           </div>
     
           <div class="media">
-            <input type="file" accept=".mp4" (change)="onVideoSelected($event)" hidden id="videoUpload">
-            <label for="videoUpload">
+            <input type="file" accept=".mp4" [id]="videoInputId" hidden (change)="onVideoSelected($event)" #videoInput>
+            <label [for]="videoInputId">
               <ng-container *ngIf="!videoPath">
                 <img *ngIf="!videoPath" src="https://i.postimg.cc/zvbh3gqD/thumbnail1.png">
               </ng-container>
               <video class="upload-video" *ngIf="videoPath" [src]="videoPath" controls></video>
             </label>   
-          </div>
+          </div>          
         </div>
     
         <div class="right__side">
@@ -48,7 +48,7 @@
                 id="{{ option.vidSize }}"
                 [disabled]="option.vidSize !== defaultSize"
                 [checked]="option.vidSize === defaultSize"
-                formContolName="mediaQuality"
+                formControlName="mediaQuality"
               />
               <label for="{{ option.vidSize }}" class="size__options">{{
                 option.vidSize
@@ -56,10 +56,11 @@
               <p class="resolution">{{ option.resolution }}</p>
             </div>
           </div>
+          
         </div>
       </div>
       <div class="apply">
-        <button type="submit" class="apply__button" [disabled]="videoModalForm.invalid" (click)="apply()">
+        <button type="submit" class="apply__button" (click)="submit()">
           {{'PAGE-CONTENT.BLOCK.BUTTONS.VIDEO-MODAL.APPLY' | transloco}}
         </button>
       </div>

--- a/libs/features/convs-mgr/stories/blocks/library/video-message-block/src/lib/modals/video-upload-modal/video-upload-modal.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/video-message-block/src/lib/modals/video-upload-modal/video-upload-modal.component.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit, ViewChild, ElementRef } from '@angular/core';
+import { Component, Inject, OnInit} from '@angular/core';
 import { FormGroup } from '@angular/forms';
 import { MAT_DIALOG_DATA, MatDialogRef } from '@angular/material/dialog';
 
@@ -10,10 +10,10 @@ import { FileStorageService } from '@app/state/file';
   styleUrls: ['./video-upload-modal.component.scss'],
 })
 export class VideoUploadModalComponent implements OnInit{
-  @ViewChild('videoInput') videoInput: ElementRef;
   videoModalForm: FormGroup;
   videoName: string;
   videoPath: string;
+  selectedVideoFile: File
 
   readonly defaultSize = "Don't Encode Media";
  
@@ -45,7 +45,6 @@ export class VideoUploadModalComponent implements OnInit{
 
   closeModal() {
     this.videoModalForm.controls['fileName'].setValue(''); // Clear the value of fileName control
-    this.videoName = '';
     this.dialogRef.close();
   }
   
@@ -55,7 +54,8 @@ export class VideoUploadModalComponent implements OnInit{
   }
 
   async apply() {
-    const videoFile = this.videoInput.nativeElement.files[0] as File;
+    const videoFile = this.selectedVideoFile;
+
   
     if (videoFile) {
       const videoName = this.videoModalForm.controls['fileName'].value || videoFile.name;
@@ -70,16 +70,15 @@ export class VideoUploadModalComponent implements OnInit{
   }
   
   onVideoSelected(event: any) {
-    const file = event.target.files[0] as File;
+    this.selectedVideoFile = event.target.files[0] as File;
   
-    if (file) {
+    if (this.selectedVideoFile) {
       const reader = new FileReader();
-      reader.readAsDataURL(file);
+      reader.readAsDataURL(this.selectedVideoFile);
       reader.onload = () => {
         const videoUrl = reader.result as string;
         this.videoPath = videoUrl;
-        this.videoName = file.name;
-        this.videoModalForm.patchValue({ fileName: this.videoName });
+        this.videoModalForm.patchValue({ fileName: this.selectedVideoFile.name });
       };
     }
   }

--- a/libs/features/convs-mgr/stories/blocks/library/video-message-block/src/lib/modals/video-upload-modal/video-upload-modal.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/video-message-block/src/lib/modals/video-upload-modal/video-upload-modal.component.ts
@@ -44,6 +44,8 @@ export class VideoUploadModalComponent implements OnInit{
   }
 
   closeModal() {
+    this.videoModalForm.controls['fileName'].setValue(''); // Clear the value of fileName control
+    this.videoName = '';
     this.dialogRef.close();
   }
   

--- a/libs/features/convs-mgr/stories/blocks/library/video-message-block/src/lib/modals/video-upload-modal/video-upload-modal.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/video-message-block/src/lib/modals/video-upload-modal/video-upload-modal.component.ts
@@ -49,7 +49,6 @@ export class VideoUploadModalComponent implements OnInit{
   
 
   submit(){
-    console.log('submit was clicked')
     this.apply()
   }
 


### PR DESCRIPTION
# Description
Before this, whenever you selected a video, it was uploaded automatically. 
I have made changes so that whenever you select a video it just renders to the UI. 
You have to click the apply button now to upload the video. 
when you click close, the video is not uploaded and the patched name is cleared. 

Fixes #486

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


# Screenshot (optional)
[Screencast from 24-05-23 22:10:37.webm](https://github.com/italanta/elewa/assets/109944021/3a8e7949-5096-47d1-be56-b82a3b5175a8)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
- [x] Test A: When I click close and check on firebase storage, the video has not been uploaded. However, when I click apply, the video is uploaded.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
