### PR TITLE
Change jump block drop down menu into text field #501

### DIFF
--- a/libs/features/convs-mgr/stories/blocks/library/jump-story-block/src/lib/components/jump-block/jump-block.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/jump-story-block/src/lib/components/jump-block/jump-block.component.html
@@ -5,10 +5,13 @@
       <option [value]="null" [selected]="true">{{"PAGE-CONTENT.BLOCK.PLACEHOLDER.JUMP.SELECT-STORY" | transloco}}</option>
     </select>
 
-    <select id="block" name="block" formControlName="targetBlockId">
+    <!-- <select id="block" name="block" formControlName="targetBlockId">
       <option *ngFor="let block of blocks" [value]='block.id'>{{block.id}}</option>
       <option value="null" [selected]="true">{{"PAGE-CONTENT.BLOCK.PLACEHOLDER.JUMP.SELECT-BLOCK" | transloco}}</option>
-    </select>
+    </select> -->
+    <input id="block" formControlName="message" type="text"
+			[placeholder]="'PAGE-CONTENT.BLOCK.PLACEHOLDER.JUMP.SELECT-BLOCK' | transloco" />
+
 
     <div formArrayName="options" fxFlexFill>
       <div *ngFor="let option of jumpBlockOptions; let i = index" class="full-width" fxFlexFill>

--- a/libs/features/convs-mgr/stories/blocks/library/jump-story-block/src/lib/components/jump-block/jump-block.component.scss
+++ b/libs/features/convs-mgr/stories/blocks/library/jump-story-block/src/lib/components/jump-block/jump-block.component.scss
@@ -10,3 +10,12 @@ select {
 	padding: 10px;
 	max-width: 24rem;
 }
+
+input {
+	max-width: 100%;
+	margin: 5px 0;
+	border: 1px solid var(--convs-mgr-color-primary-purple);
+	border-radius: 5px;
+	resize: none;
+	padding: 10px;
+}


### PR DESCRIPTION
# Description

Currently the jump block required  the user to select the ID of the block to jump to from a drop-down menu. In order to be able to paste the block ID into the jump block, i converted it to to an input file



Fixes  #501

## Type of change

Please delete options that are not relevant.


- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# Screenshot (optional)

[Untitled_ May 26, 2023 11_37 AM.webm](https://github.com/italanta/elewa/assets/110150366/88db8f96-09a8-45ba-b94c-891da93e6254)






# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
