### PR TITLE
:art: Restrict Blocks from overlapping each other #516

### DIFF
--- a/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
@@ -221,6 +221,13 @@ export class StoryEditorFrame {
     const xOffset = 50; //Adding vertical and horizontal spacing between blocks
     const yOffset = 50;
 
+    let maxY = 0;
+    if (this._blocks.length > 0) {
+      maxY = Math.max(
+        ...this._blocks.map((block) => block.position.y + blockHeight)
+      );
+    }
+    
     const block = {
       id: `${this._cnt}`,
       type: type,

--- a/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
@@ -215,6 +215,12 @@ export class StoryEditorFrame {
    * TODO: Move this to a factory later
    */
   newBlock(type: StoryBlockTypes, coordinates?:Coordinate) {
+    const blockWidth = 300 //Assuming default block height and width
+    const blockHeight = 100 
+
+    const xOffset = 50; //Adding vertical and horizontal spacing between blocks
+    const yOffset = 50;
+
     const block = {
       id: `${this._cnt}`,
       type: type,

--- a/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
@@ -219,7 +219,7 @@ export class StoryEditorFrame {
     const blockHeight = 100 
 
     const xOffset = 50; //Adding vertical and horizontal spacing between blocks
-    const yOffset = 50;
+    const yOffset = 80;
 
     let maxY = 0;
     if (this._blocks.length > 0) {
@@ -227,13 +227,20 @@ export class StoryEditorFrame {
         ...this._blocks.map((block) => block.position.y + blockHeight)
       );
     }
-    
+
+    let initialY = 0;
+    if (this._blocks.length === 0) {
+      // Set the initial position of block
+      initialY = 50; 
+    }
+
     const block = {
       id: `${this._cnt}`,
       type: type,
       message: '',
       // TODO: Positioning in the middle + offset based on _cnt
-      position: coordinates || { x: 200, y: 50 },
+      position: coordinates || {  x: 200 + this._blocks.length * (blockWidth + xOffset),
+        y: initialY !== 0 ? maxY + yOffset : initialY,},
     } as StoryBlock;
 
     this._cnt++;


### PR DESCRIPTION
# Description
A user should be able to render blocks without them overlapping. I have implemented this by:

1. Taking into account both the horizontal and vertical spacing between blocks, ensuring they are positioned without overlapping. 
2. The `x` coordinate of each block is calculated based on the block's index, width, and horizontal spacing, while the `y` coordinate is determined based on the maximum `y` coordinate of the previous blocks, taking into account the block's height and vertical spacing.

This implementation should place the blocks in a visually appealing and non-overlapping manner.

Fixes #516

## Type of change

- [ ] New feature (non-breaking change which adds functionality)


# Screenshot (optional)

https://github.com/italanta/elewa/assets/109944021/ad489ca9-c113-4e82-8bf1-269c263d156b


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

