### PR TITLE
:bug: :mag: When I search for an item I should only see relevant results fix #466

### DIFF
--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.html
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.html
@@ -9,7 +9,7 @@
   <div fxLayout="column" *ngIf="blockTemplate$ | async as blocks" fxFlex>
     <!-- message block -->
     <div class="block-list">
-      <h6 *ngIf="filteredBlocks.length > 0 && blocksInCategory('messages-block', filteredBlocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MESSAGE-BLOCK' | transloco }}</h6>
+      <h6 *ngIf="blocks | blockCategoryPipe: 'messages-block': (filterInput$$ | async) ?? ''">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MESSAGE-BLOCK' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'messages-block'">
@@ -33,7 +33,7 @@
     </div>
     <!-- questions block -->
     <div class="block-list">
-      <h6 *ngIf="filteredBlocks.length > 0 && blocksInCategory('questions-block', filteredBlocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.QUESTION-BLOCKS' | transloco }}</h6>
+      <h6 *ngIf="blocks | blockCategoryPipe: 'questions-block': (filterInput$$ | async) ?? ''">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.QUESTION-BLOCKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'questions-block'">
@@ -57,7 +57,7 @@
     </div>
      <!-- Image block -->
     <div class="block-list">
-      <h6 *ngIf="filteredBlocks.length > 0 && blocksInCategory('images-block', filteredBlocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.IMAGE-BLOCKS' | transloco }}</h6>
+      <h6 *ngIf="blocks | blockCategoryPipe: 'images-block': (filterInput$$ | async) ?? ''">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.IMAGE-BLOCKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'images-block'">
@@ -81,7 +81,7 @@
     </div>
     <!-- documents block -->
     <div class="block-list">
-      <h6 *ngIf="filteredBlocks.length > 0 && blocksInCategory('documents-block', filteredBlocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.DOCUMENT-BLOCKS' | transloco }}</h6>
+      <h6 *ngIf="blocks | blockCategoryPipe: 'documents-block': (filterInput$$ | async) ?? ''">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.DOCUMENT-BLOCKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'documents-block'">
@@ -105,7 +105,7 @@
     </div>
      <!-- multimedia block -->
      <div class="block-list">
-      <h6 *ngIf="filteredBlocks.length > 0 && blocksInCategory('multimedia-block', filteredBlocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MULTIMEDIA-BLOCKS' | transloco }}</h6>
+      <h6 *ngIf="blocks | blockCategoryPipe: 'multimedia-block': (filterInput$$ | async) ?? ''">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MULTIMEDIA-BLOCKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'multimedia-block'">
@@ -129,7 +129,7 @@
     </div>
     <!-- end block -->
     <div class="block-list">
-      <h6 *ngIf="filteredBlocks.length > 0 && blocksInCategory('end-block', filteredBlocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.END-BLOCK' | transloco }}</h6>
+      <h6 *ngIf="blocks | blockCategoryPipe: 'end-block': (filterInput$$ | async) ?? ''">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.END-BLOCK' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'end-block'">
@@ -154,7 +154,7 @@
 
     <!-- bricks -->
     <div class="block-list">
-      <h6 *ngIf="filteredBlocks.length > 0 && blocksInCategory('bricks', filteredBlocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.BRICKS' | transloco }}</h6>
+      <h6 *ngIf="blocks | blockCategoryPipe: 'bricks': (filterInput$$ | async) ?? ''">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.BRICKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'bricks'">

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.html
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.html
@@ -9,7 +9,7 @@
   <div fxLayout="column" *ngIf="blockTemplate$ | async as blocks" fxFlex>
     <!-- message block -->
     <div class="block-list">
-      <h6 class="message-block" *ngIf="inputText && hasMatchingBlocks('messages-block', blocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MESSAGE-BLOCK' | transloco }}</h6>
+      <h6 *ngIf="filteredBlocks.length > 0 && blocksInCategory('messages-block', filteredBlocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MESSAGE-BLOCK' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'messages-block'">
@@ -33,7 +33,7 @@
     </div>
     <!-- questions block -->
     <div class="block-list">
-      <h6 *ngIf="inputText && hasMatchingBlocks('questions-block', blocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.QUESTION-BLOCKS' | transloco }}</h6>
+      <h6 *ngIf="filteredBlocks.length > 0 && blocksInCategory('questions-block', filteredBlocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.QUESTION-BLOCKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'questions-block'">
@@ -57,7 +57,7 @@
     </div>
      <!-- Image block -->
     <div class="block-list">
-      <h6 *ngIf="inputText && hasMatchingBlocks('images-block', blocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.IMAGE-BLOCKS' | transloco }}</h6>
+      <h6 *ngIf="filteredBlocks.length > 0 && blocksInCategory('images-block', filteredBlocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.IMAGE-BLOCKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'images-block'">
@@ -81,7 +81,7 @@
     </div>
     <!-- documents block -->
     <div class="block-list">
-      <h6 *ngIf="inputText && hasMatchingBlocks('documents-block', blocks)" >{{ 'PAGE-CONTENT.BLOCK-CATEGORY.DOCUMENT-BLOCKS' | transloco }}</h6>
+      <h6 *ngIf="filteredBlocks.length > 0 && blocksInCategory('documents-block', filteredBlocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.DOCUMENT-BLOCKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'documents-block'">
@@ -105,7 +105,7 @@
     </div>
      <!-- multimedia block -->
      <div class="block-list">
-      <h6 *ngIf="inputText && hasMatchingBlocks('multimedia-block', blocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MULTIMEDIA-BLOCKS' | transloco }}</h6>
+      <h6 *ngIf="filteredBlocks.length > 0 && blocksInCategory('multimedia-block', filteredBlocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MULTIMEDIA-BLOCKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'multimedia-block'">
@@ -129,7 +129,7 @@
     </div>
     <!-- end block -->
     <div class="block-list">
-      <h6 *ngIf="inputText && hasMatchingBlocks('end-block', blocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.END-BLOCK' | transloco }}</h6>
+      <h6 *ngIf="filteredBlocks.length > 0 && blocksInCategory('end-block', filteredBlocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.END-BLOCK' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'end-block'">
@@ -154,7 +154,7 @@
 
     <!-- bricks -->
     <div class="block-list">
-      <h6 *ngIf="inputText && hasMatchingBlocks('bricks', blocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.BRICKS' | transloco }}</h6>
+      <h6 *ngIf="filteredBlocks.length > 0 && blocksInCategory('bricks', filteredBlocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.BRICKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'bricks'">

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.html
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.html
@@ -7,175 +7,124 @@
   </div>
 
   <div fxLayout="column" *ngIf="blockTemplate$ | async as blocks" fxFlex>
+
     <!-- message block -->
-    <div class="block-list">
-      <h6 *ngIf="blocks | blockCategoryPipe: 'messages-block': (filterInput$$ | async) ?? ''">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MESSAGE-BLOCK' | transloco }}</h6>
+    <div class="block-list" *ngIf="blocks | blockCategoryPipe: 'messages-block' as groupedBlocks">
+      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MESSAGE-BLOCK' | transloco }}</h6>
       <div class="blocks">
-        <ng-container *ngFor="let block of blocks; let i = index">
-          <div *ngIf="block.blockCategory === 'messages-block'">
-            <div>
-              <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
-                <div
-                  fxLayout="column"
-                  fxLayoutAlign="center center"
-                  class="blocks-main"
-                >
-                  <i class="{{ block.blockIcon }}" id="icons"></i>
-                </div>
-                <p class="block-messages">
-                  {{ block.message }}
-                </p>
-              </div>
+        <ng-container *ngFor="let block of groupedBlocks">
+          <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
+            <div fxLayout="column" fxLayoutAlign="center center" class="blocks-main">
+              <i class="{{ block.blockIcon }}" id="icons"></i>
             </div>
+            <p class="block-messages">
+              {{ block.message }}
+            </p>
           </div>
         </ng-container>
       </div>
     </div>
+
     <!-- questions block -->
-    <div class="block-list">
-      <h6 *ngIf="blocks | blockCategoryPipe: 'questions-block': (filterInput$$ | async) ?? ''">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.QUESTION-BLOCKS' | transloco }}</h6>
+    <div class="block-list" *ngIf="blocks | blockCategoryPipe: 'questions-block' as groupedBlocks">
+      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.QUESTION-BLOCKS' | transloco }}</h6>
       <div class="blocks">
-        <ng-container *ngFor="let block of blocks; let i = index">
-          <div *ngIf="block.blockCategory === 'questions-block'">
-            <div>
-              <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
-                <div
-                  fxLayout="column"
-                  fxLayoutAlign="center center"
-                  class="blocks-main"
-                >
-                  <i class="{{ block.blockIcon }}" id="icons"></i>
-                </div>
-                <p class="block-messages">
-                  {{ block.message }}
-                </p>
-              </div>
+        <ng-container *ngFor="let block of groupedBlocks">
+          <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
+            <div fxLayout="column" fxLayoutAlign="center center" class="blocks-main">
+              <i class="{{ block.blockIcon }}" id="icons"></i>
             </div>
+            <p class="block-messages">
+              {{ block.message }}
+            </p>
           </div>
         </ng-container>
       </div>
     </div>
-     <!-- Image block -->
-    <div class="block-list">
-      <h6 *ngIf="blocks | blockCategoryPipe: 'images-block': (filterInput$$ | async) ?? ''">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.IMAGE-BLOCKS' | transloco }}</h6>
+
+    <!-- Image block -->
+    <div class="block-list" *ngIf="blocks | blockCategoryPipe: 'images-block' as groupedBlocks">
+      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.IMAGE-BLOCKS' | transloco }}</h6>
       <div class="blocks">
-        <ng-container *ngFor="let block of blocks; let i = index">
-          <div *ngIf="block.blockCategory === 'images-block'">
-            <div>
-              <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
-                <div
-                  fxLayout="column"
-                  fxLayoutAlign="center center"
-                  class="blocks-main"
-                >
-                  <i class="{{ block.blockIcon }}" id="icons"></i>
-                </div>
-                <p class="block-messages">
-                  {{ block.message }}
-                </p>
-              </div>
+        <ng-container *ngFor="let block of groupedBlocks">
+          <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
+            <div fxLayout="column" fxLayoutAlign="center center" class="blocks-main">
+              <i class="{{ block.blockIcon }}" id="icons"></i>
             </div>
+            <p class="block-messages">
+              {{ block.message }}
+            </p>
           </div>
         </ng-container>
       </div>
     </div>
+
     <!-- documents block -->
-    <div class="block-list">
-      <h6 *ngIf="blocks | blockCategoryPipe: 'documents-block': (filterInput$$ | async) ?? ''">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.DOCUMENT-BLOCKS' | transloco }}</h6>
+    <div class="block-list" *ngIf="blocks | blockCategoryPipe: 'documents-block' as groupedBlocks">
+      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.DOCUMENT-BLOCKS' | transloco }}</h6>
       <div class="blocks">
-        <ng-container *ngFor="let block of blocks; let i = index">
-          <div *ngIf="block.blockCategory === 'documents-block'">
-            <div>
-              <div (click)="addBlock(block.type)"  draggable="true" (dragend)="onDragEnd(block.type)" class="block">
-                <div
-                  fxLayout="column"
-                  fxLayoutAlign="center center"
-                  class="blocks-main"
-                >
-                  <i class="{{ block.blockIcon }}" id="icons"></i>
-                </div>
-                <p class="block-messages">
-                  {{ block.message }}
-                </p>
-              </div>
+        <ng-container *ngFor="let block of groupedBlocks">
+          <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
+            <div fxLayout="column" fxLayoutAlign="center center" class="blocks-main">
+              <i class="{{ block.blockIcon }}" id="icons"></i>
             </div>
+            <p class="block-messages">
+              {{ block.message }}
+            </p>
           </div>
         </ng-container>
       </div>
     </div>
-     <!-- multimedia block -->
-     <div class="block-list">
-      <h6 *ngIf="blocks | blockCategoryPipe: 'multimedia-block': (filterInput$$ | async) ?? ''">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MULTIMEDIA-BLOCKS' | transloco }}</h6>
+
+    <!-- multimedia block -->
+    <div class="block-list" *ngIf="blocks | blockCategoryPipe: 'multimedia-block' as groupedBlocks">
+      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MULTIMEDIA-BLOCKS' | transloco }}</h6>
       <div class="blocks">
-        <ng-container *ngFor="let block of blocks; let i = index">
-          <div *ngIf="block.blockCategory === 'multimedia-block'">
-            <div>
-              <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
-                <div
-                  fxLayout="column"
-                  fxLayoutAlign="center center"
-                  class="blocks-main"
-                >
-                  <i class="{{ block.blockIcon }}" id="icons"></i>
-                </div>
-                <p class="block-messages">
-                  {{ block.message }}
-                </p>
-              </div>
+        <ng-container *ngFor="let block of groupedBlocks">
+          <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
+            <div fxLayout="column" fxLayoutAlign="center center" class="blocks-main">
+              <i class="{{ block.blockIcon }}" id="icons"></i>
             </div>
+            <p class="block-messages">
+              {{ block.message }}
+            </p>
           </div>
         </ng-container>
       </div>
     </div>
+
     <!-- end block -->
-    <div class="block-list">
-      <h6 *ngIf="blocks | blockCategoryPipe: 'end-block': (filterInput$$ | async) ?? ''">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.END-BLOCK' | transloco }}</h6>
+    <div class="block-list" *ngIf="blocks | blockCategoryPipe: 'end-block' as groupedBlocks">
+      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.END-BLOCK' | transloco }}</h6>
       <div class="blocks">
-        <ng-container *ngFor="let block of blocks; let i = index">
-          <div *ngIf="block.blockCategory === 'end-block'">
-            <div>
-              <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
-                <div
-                  fxLayout="column"
-                  fxLayoutAlign="center center"
-                  class="blocks-main"
-                >
-                  <i class="{{ block.blockIcon }}" id="icons"></i>
-                </div>
-                <p class="block-messages">
-                  {{ block.message }}
-                </p>
-              </div>
+        <ng-container *ngFor="let block of groupedBlocks">
+          <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
+            <div fxLayout="column" fxLayoutAlign="center center" class="blocks-main">
+              <i class="{{ block.blockIcon }}" id="icons"></i>
             </div>
+            <p class="block-messages">
+              {{ block.message }}
+            </p>
           </div>
         </ng-container>
       </div>
     </div>
 
     <!-- bricks -->
-    <div class="block-list">
-      <h6 *ngIf="blocks | blockCategoryPipe: 'bricks': (filterInput$$ | async) ?? ''">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.BRICKS' | transloco }}</h6>
+    <div class="block-list" *ngIf="blocks | blockCategoryPipe: 'bricks' as groupedBlocks">
+      <h6 *ngIf="groupedBlocks.length">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.BRICKS' | transloco }}</h6>
       <div class="blocks">
-        <ng-container *ngFor="let block of blocks; let i = index">
-          <div *ngIf="block.blockCategory === 'bricks'">
-            <div>
-              <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
-                <div
-                  fxLayout="column"
-                  fxLayoutAlign="center center"
-                  class="blocks-main"
-                >
-                  <i class="{{ block.blockIcon }}" id="icons"></i>
-                </div>
-                <p class="block-messages">
-                  {{ block.message }}
-                </p>
-              </div>
+        <ng-container *ngFor="let block of groupedBlocks">
+          <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
+            <div fxLayout="column" fxLayoutAlign="center center" class="blocks-main">
+              <i class="{{ block.blockIcon }}" id="icons"></i>
             </div>
+            <p class="block-messages">
+              {{ block.message }}
+            </p>
           </div>
         </ng-container>
       </div>
     </div>
   </div>
 </div>
-

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.html
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.html
@@ -7,124 +7,46 @@
   </div>
 
   <div fxLayout="column" *ngIf="blockTemplate$ | async as blocks" fxFlex>
-
     <!-- message block -->
     <div class="block-list" *ngIf="blocks | blockCategoryPipe: 'messages-block' as groupedBlocks">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MESSAGE-BLOCK' | transloco }}</h6>
-      <div class="blocks">
-        <ng-container *ngFor="let block of groupedBlocks">
-          <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
-            <div fxLayout="column" fxLayoutAlign="center center" class="blocks-main">
-              <i class="{{ block.blockIcon }}" id="icons"></i>
-            </div>
-            <p class="block-messages">
-              {{ block.message }}
-            </p>
-          </div>
-        </ng-container>
-      </div>
+      <h6 class="first-title" *ngIf="groupedBlocks.length">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MESSAGE-BLOCK' | transloco }}</h6>
+      <convl-grouped-blocks [groupedBlocks]="groupedBlocks" [frame]="frame"></convl-grouped-blocks>
     </div>
 
     <!-- questions block -->
     <div class="block-list" *ngIf="blocks | blockCategoryPipe: 'questions-block' as groupedBlocks">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.QUESTION-BLOCKS' | transloco }}</h6>
-      <div class="blocks">
-        <ng-container *ngFor="let block of groupedBlocks">
-          <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
-            <div fxLayout="column" fxLayoutAlign="center center" class="blocks-main">
-              <i class="{{ block.blockIcon }}" id="icons"></i>
-            </div>
-            <p class="block-messages">
-              {{ block.message }}
-            </p>
-          </div>
-        </ng-container>
-      </div>
+      <h6 *ngIf="groupedBlocks.length">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.QUESTION-BLOCKS' | transloco }}</h6>
+      <convl-grouped-blocks [groupedBlocks]="groupedBlocks" [frame]="frame"></convl-grouped-blocks>
     </div>
 
     <!-- Image block -->
     <div class="block-list" *ngIf="blocks | blockCategoryPipe: 'images-block' as groupedBlocks">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.IMAGE-BLOCKS' | transloco }}</h6>
-      <div class="blocks">
-        <ng-container *ngFor="let block of groupedBlocks">
-          <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
-            <div fxLayout="column" fxLayoutAlign="center center" class="blocks-main">
-              <i class="{{ block.blockIcon }}" id="icons"></i>
-            </div>
-            <p class="block-messages">
-              {{ block.message }}
-            </p>
-          </div>
-        </ng-container>
-      </div>
+      <h6 *ngIf="groupedBlocks.length">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.IMAGE-BLOCKS' | transloco }}</h6>
+      <convl-grouped-blocks [groupedBlocks]="groupedBlocks" [frame]="frame"></convl-grouped-blocks>
     </div>
 
     <!-- documents block -->
     <div class="block-list" *ngIf="blocks | blockCategoryPipe: 'documents-block' as groupedBlocks">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.DOCUMENT-BLOCKS' | transloco }}</h6>
-      <div class="blocks">
-        <ng-container *ngFor="let block of groupedBlocks">
-          <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
-            <div fxLayout="column" fxLayoutAlign="center center" class="blocks-main">
-              <i class="{{ block.blockIcon }}" id="icons"></i>
-            </div>
-            <p class="block-messages">
-              {{ block.message }}
-            </p>
-          </div>
-        </ng-container>
-      </div>
+      <h6 *ngIf="groupedBlocks.length">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.DOCUMENT-BLOCKS' | transloco }}</h6>
+      <convl-grouped-blocks [groupedBlocks]="groupedBlocks" [frame]="frame"></convl-grouped-blocks>
     </div>
 
     <!-- multimedia block -->
     <div class="block-list" *ngIf="blocks | blockCategoryPipe: 'multimedia-block' as groupedBlocks">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MULTIMEDIA-BLOCKS' | transloco }}</h6>
-      <div class="blocks">
-        <ng-container *ngFor="let block of groupedBlocks">
-          <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
-            <div fxLayout="column" fxLayoutAlign="center center" class="blocks-main">
-              <i class="{{ block.blockIcon }}" id="icons"></i>
-            </div>
-            <p class="block-messages">
-              {{ block.message }}
-            </p>
-          </div>
-        </ng-container>
-      </div>
+      <h6 *ngIf="groupedBlocks.length">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MULTIMEDIA-BLOCKS' | transloco }}</h6>
+      <convl-grouped-blocks [groupedBlocks]="groupedBlocks" [frame]="frame"></convl-grouped-blocks>
     </div>
 
     <!-- end block -->
     <div class="block-list" *ngIf="blocks | blockCategoryPipe: 'end-block' as groupedBlocks">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.END-BLOCK' | transloco }}</h6>
-      <div class="blocks">
-        <ng-container *ngFor="let block of groupedBlocks">
-          <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
-            <div fxLayout="column" fxLayoutAlign="center center" class="blocks-main">
-              <i class="{{ block.blockIcon }}" id="icons"></i>
-            </div>
-            <p class="block-messages">
-              {{ block.message }}
-            </p>
-          </div>
-        </ng-container>
-      </div>
+      <h6 *ngIf="groupedBlocks.length">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.END-BLOCK' | transloco }}</h6>
+      <convl-grouped-blocks [groupedBlocks]="groupedBlocks" [frame]="frame"></convl-grouped-blocks>
     </div>
 
     <!-- bricks -->
     <div class="block-list" *ngIf="blocks | blockCategoryPipe: 'bricks' as groupedBlocks">
       <h6 *ngIf="groupedBlocks.length">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.BRICKS' | transloco }}</h6>
-      <div class="blocks">
-        <ng-container *ngFor="let block of groupedBlocks">
-          <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
-            <div fxLayout="column" fxLayoutAlign="center center" class="blocks-main">
-              <i class="{{ block.blockIcon }}" id="icons"></i>
-            </div>
-            <p class="block-messages">
-              {{ block.message }}
-            </p>
-          </div>
-        </ng-container>
-      </div>
+      <convl-grouped-blocks [groupedBlocks]="groupedBlocks" [frame]="frame"></convl-grouped-blocks>
     </div>
   </div>
 </div>

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.html
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.html
@@ -9,7 +9,7 @@
   <div fxLayout="column" *ngIf="blockTemplate$ | async as blocks" fxFlex>
     <!-- message block -->
     <div class="block-list">
-      <h6 class="message-block">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MESSAGE-BLOCK' | transloco }}</h6>
+      <h6 class="message-block" *ngIf="inputText && hasMatchingBlocks('messages-block', blocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MESSAGE-BLOCK' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'messages-block'">
@@ -33,7 +33,7 @@
     </div>
     <!-- questions block -->
     <div class="block-list">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.QUESTION-BLOCKS' | transloco }}</h6>
+      <h6 *ngIf="inputText && hasMatchingBlocks('questions-block', blocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.QUESTION-BLOCKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'questions-block'">
@@ -57,7 +57,7 @@
     </div>
      <!-- Image block -->
     <div class="block-list">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.IMAGE-BLOCKS' | transloco }}</h6>
+      <h6 *ngIf="inputText && hasMatchingBlocks('images-block', blocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.IMAGE-BLOCKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'images-block'">
@@ -81,7 +81,7 @@
     </div>
     <!-- documents block -->
     <div class="block-list">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.DOCUMENT-BLOCKS' | transloco }}</h6>
+      <h6 *ngIf="inputText && hasMatchingBlocks('documents-block', blocks)" >{{ 'PAGE-CONTENT.BLOCK-CATEGORY.DOCUMENT-BLOCKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'documents-block'">
@@ -105,7 +105,7 @@
     </div>
      <!-- multimedia block -->
      <div class="block-list">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MULTIMEDIA-BLOCKS' | transloco }}</h6>
+      <h6 *ngIf="inputText && hasMatchingBlocks('multimedia-block', blocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.MULTIMEDIA-BLOCKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'multimedia-block'">
@@ -129,7 +129,7 @@
     </div>
     <!-- end block -->
     <div class="block-list">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.END-BLOCK' | transloco }}</h6>
+      <h6 *ngIf="inputText && hasMatchingBlocks('end-block', blocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.END-BLOCK' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'end-block'">
@@ -154,7 +154,7 @@
 
     <!-- bricks -->
     <div class="block-list">
-      <h6>{{ 'PAGE-CONTENT.BLOCK-CATEGORY.BRICKS' | transloco }}</h6>
+      <h6 *ngIf="inputText && hasMatchingBlocks('bricks', blocks)">{{ 'PAGE-CONTENT.BLOCK-CATEGORY.BRICKS' | transloco }}</h6>
       <div class="blocks">
         <ng-container *ngFor="let block of blocks; let i = index">
           <div *ngIf="block.blockCategory === 'bricks'">

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.scss
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.scss
@@ -1,105 +1,69 @@
 .nav {
-	max-width: 100%;
-	max-height: calc(100vh - 64px);
-	padding:10px;
-	margin-bottom: 20%;
-	overflow-y: hidden;
-	scrollbar-gutter: stable both-edges;
-  background-color: #F0EFF3;
+  max-width: 100%;
+  max-height: calc(100vh - 64px);
+  padding: 10px;
+  margin-bottom: 20%;
+  overflow-y: hidden;
+  scrollbar-gutter: stable both-edges;
+  background-color: #f0eff3;
   color: slategray;
-
 }
 
-.nav:hover{
-	overflow-y: scroll;
-	scrollbar-gutter: stable both-edges;
+.nav:hover {
+  overflow-y: scroll;
+  scrollbar-gutter: stable both-edges;
 }
 
 ::-webkit-scrollbar {
-	width: 5px;
-  }
+  width: 5px;
+}
 
 .search-input {
   width: 100%;
 }
 
-.search, .search input {
-	max-width: 100%;
-}
-.block-wrapper{
-	height: max-content;
+.search,
+.search input {
+  max-width: 100%;
 }
 
-.block-list{
-  margin-bottom: 1rem;
-  h6{
-    margin-bottom: .4rem;
+.block-list {
+  h6 {
+    margin-bottom: 0.4rem;
     font-size: 0.8rem;
     margin-top: 0px;
+
+    &:not(.first-title) {
+      margin-top: 1rem;
+    }
   }
-  .blocks{
+
+  .blocks {
     display: grid;
     grid-template-columns: repeat(3, 1fr);
     gap: 8px;
-    .blocks-main {
-      height: 60px;
-      border-radius: 5px;
-      word-wrap: break-word;
-      background-color: #FFF;
-      box-shadow: 0px 10px -14px 14px #FFF;
+
+    #icons {
+      color: slategray;
+      font-weight: 900;
+      align-items: center;
+
+      fill: white;
+      font-size: large;
     }
-    p{
-      padding: 0;
-      margin: 0;
-    }
-
-    .blocks-main:hover {
-      background-color: #FBC113 !important;
-
-      #icons {
-        color: white !important;
-      }
-    }
-
-
-#icons {
-	color: slategray;
-	font-weight: 900;
-	align-items: center;
-
-	fill: white;
-	font-size: large;
-
-}
-
-.block-messages {
-	font-size: 0.7rem;
-	text-align: center;
-	white-space:normal;
-	word-break:normal;
-	height: max-content;
-	font-weight: 500;
-	color: slategray;
-  margin: 0;
-}
-
-
   }
 }
 
-
-
-
-
 ::ng-deep .mat-mdc-form-field {
-	max-width: 100%;
+  max-width: 100%;
 }
 
-::ng-deep .mat-mdc-form-field-infix{
+::ng-deep .mat-mdc-form-field-infix {
   min-height: 50px !important;
 }
 
-::ng-deep .mat-mdc-form-field-icon-prefix>.mat-icon, .mat-mdc-form-field-icon-suffix>.mat-icon {
+::ng-deep .mat-mdc-form-field-icon-prefix > .mat-icon,
+.mat-mdc-form-field-icon-suffix > .mat-icon {
   padding-right: 2px !important;
 }
 
@@ -115,7 +79,3 @@
   border: 2px solid var(--convs-mgr-color-text-white) !important;
   border-left: none !important;
 }
-
-
-
-

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
@@ -34,7 +34,7 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
 
   @Input() frame: StoryEditorFrame;
   filterInput$$: BehaviorSubject<string> = new BehaviorSubject<string>('');
-  inputText = true
+  filteredBlocks: StoryBlock[] = [];
 
   blockTemplates: StoryBlock[] = [
     { id: 'input-message-block', type: StoryBlockTypes.TextMessage, message: 'Message', blockIcon: this.getBlockIcon(StoryBlockTypes.TextMessage), blockCategory: 'messages-block' } as TextMessageBlock,
@@ -186,31 +186,16 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
   //A function that subscribes to when the search control changes and filters the blocks components list
   filterBlockTemplates() {
     this.blockTemplate$ = combineLatest([this.filterInput$$, this.blockTemplate$])
-    .pipe(map(([filter, blocksArray]) => {
-      const filteredBlocks = blocksArray.filter((block: StoryBlock) => {
-        return block.message?.toString().toLowerCase().includes(filter);
-      });
-
-      // Check if any of the filtered blocks have a message that matches the filter
-      const hasMatchingMessage = filteredBlocks.some((block: StoryBlock) => {
-        return block.message?.toString().toLowerCase().includes(filter);
-      });
-
-      // Set inputText to true if there is at least one matching message
-      this.inputText = hasMatchingMessage;
-
-      return filteredBlocks;
-    }));
-  }
-
-  hasMatchingBlocks(category: string, blocks: StoryBlock[]): boolean {
-    return blocks.some((block: StoryBlock) => {
-      return block.blockCategory === category && block.message?.toString().toLowerCase().includes(this.filterInput$$.getValue());
-    });
+      .pipe(map(([filter, blocksArray]) => {
+        this.filteredBlocks = blocksArray.filter((block: StoryBlock) => {
+          return block.message?.toString().toLowerCase().includes(filter);
+        });
+  
+        return this.filteredBlocks;
+      }));
   }
   
   filterBlocks(event: any) {
-    this.inputText = false
     this.filterInput$$.next(event.target.value);
   }
 

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
@@ -187,12 +187,13 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
     this.blockTemplate$ = combineLatest([this.filterInput$$, this.blockTemplate$])
       .pipe(map(([filter, blocksArray]) => blocksArray
         .filter((block: StoryBlock) => {
-          return block.message?.toString().toLowerCase().includes(filter)
+          return block.message?.toString().toLowerCase().includes(filter) || block.blockTitle?.toString().toLowerCase().includes(filter);
         })))
   }
 
   filterBlocks(event: any) {
-    this.filterInput$$.next(event.target.value);
+    const searchTerm = event.target.value.toLowerCase();
+    this.filterInput$$.next(searchTerm);
   }
 
   onDragEnd(blockType: number){

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
@@ -34,6 +34,7 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
 
   @Input() frame: StoryEditorFrame;
   filterInput$$: BehaviorSubject<string> = new BehaviorSubject<string>('');
+  inputText = true
 
   blockTemplates: StoryBlock[] = [
     { id: 'input-message-block', type: StoryBlockTypes.TextMessage, message: 'Message', blockIcon: this.getBlockIcon(StoryBlockTypes.TextMessage), blockCategory: 'messages-block' } as TextMessageBlock,
@@ -185,13 +186,25 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
   //A function that subscribes to when the search control changes and filters the blocks components list
   filterBlockTemplates() {
     this.blockTemplate$ = combineLatest([this.filterInput$$, this.blockTemplate$])
-      .pipe(map(([filter, blocksArray]) => blocksArray
-        .filter((block: StoryBlock) => {
-          return block.message?.toString().toLowerCase().includes(filter)
-        })))
-  }
+    .pipe(map(([filter, blocksArray]) => {
+      const filteredBlocks = blocksArray.filter((block: StoryBlock) => {
+        return block.message?.toString().toLowerCase().includes(filter);
+      });
 
+      // Check if any of the filtered blocks have a message that matches the filter
+      const hasMatchingMessage = filteredBlocks.some((block: StoryBlock) => {
+        return block.message?.toString().toLowerCase().includes(filter);
+      });
+
+      // Set inputText to true if there is at least one matching message
+      this.inputText = hasMatchingMessage;
+
+      return filteredBlocks;
+    }));
+  }
+  
   filterBlocks(event: any) {
+   // this.inputText = false
     this.filterInput$$.next(event.target.value);
   }
 

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
@@ -34,6 +34,7 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
 
   @Input() frame: StoryEditorFrame;
   filterInput$$: BehaviorSubject<string> = new BehaviorSubject<string>('');
+  //filterInput$$ = '';
   filteredBlocks: StoryBlock[] = [];
 
   blockTemplates: StoryBlock[] = [
@@ -193,12 +194,6 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
   
         return this.filteredBlocks;
       }));
-  }
-  
-  blocksInCategory(category: string, blocks: StoryBlock[]): boolean {
-    return blocks.some((block: StoryBlock) => {
-      return block.blockCategory === category;
-    });
   }
 
   filterBlocks(event: any) {

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
@@ -195,6 +195,12 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
       }));
   }
   
+  blocksInCategory(category: string, blocks: StoryBlock[]): boolean {
+    return blocks.some((block: StoryBlock) => {
+      return block.blockCategory === category;
+    });
+  }
+
   filterBlocks(event: any) {
     this.filterInput$$.next(event.target.value);
   }

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
@@ -210,7 +210,7 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
   }
   
   filterBlocks(event: any) {
-   // this.inputText = false
+    this.inputText = false
     this.filterInput$$.next(event.target.value);
   }
 

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
@@ -202,6 +202,12 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
       return filteredBlocks;
     }));
   }
+
+  hasMatchingBlocks(category: string, blocks: StoryBlock[]): boolean {
+    return blocks.some((block: StoryBlock) => {
+      return block.blockCategory === category && block.message?.toString().toLowerCase().includes(this.filterInput$$.getValue());
+    });
+  }
   
   filterBlocks(event: any) {
    // this.inputText = false

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
@@ -10,7 +10,7 @@ import { StoryBlockTypes } from '@app/model/convs-mgr/stories/blocks/main';
 import {
   ImageMessageBlock, LocationMessageBlock, NameMessageBlock, QuestionMessageBlock,
   TextMessageBlock, EmailMessageBlock, PhoneMessageBlock, DocumentMessageBlock, StickerMessageBlock,
-  VoiceMessageBlock, VideoMessageBlock, ListMessageBlock, JumpBlock, MultipleInputMessageBlock, FailBlock,
+  VoiceMessageBlock, VideoMessageBlock, ListMessageBlock, JumpBlock, FailBlock,
   ImageInputBlock, LocationInputBlock, AudioInputBlock, VideoInputBlock, WebhookBlock, OpenEndedQuestionBlock,
   KeywordMessageBlock, MultiContentInputBlock, EndStoryAnchorBlock, EventBlock, AssessmentBrick, ConditionalBlock
 } from '@app/model/convs-mgr/stories/blocks/messaging';
@@ -18,7 +18,6 @@ import {
 import { StoryEditorFrame } from '../../model/story-editor-frame.model';
 import { DragDropService } from '../../providers/drag-drop.service';
 import { iconsAndTitles } from 'libs/features/convs-mgr/stories/blocks/library/main/src/lib/model/icons-and-titles';
-import { Coordinate } from '../../model/coordinates.interface';
 
 /**
  * Component which holds a library (list) of all blocks that can be created
@@ -34,8 +33,6 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
 
   @Input() frame: StoryEditorFrame;
   filterInput$$: BehaviorSubject<string> = new BehaviorSubject<string>('');
-  //filterInput$$ = '';
-  filteredBlocks: StoryBlock[] = [];
 
   blockTemplates: StoryBlock[] = [
     { id: 'input-message-block', type: StoryBlockTypes.TextMessage, message: 'Message', blockIcon: this.getBlockIcon(StoryBlockTypes.TextMessage), blockCategory: 'messages-block' } as TextMessageBlock,
@@ -73,7 +70,7 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
     // { id: 'end-anchor-block', type:StoryBlockTypes.EndStoryAnchorBlock, message: 'End Story', blockIcon:this.getBlockIcon(StoryBlockTypes.EndStoryAnchorBlock), blockCategory: 'end-block'} as EndStoryAnchorBlock
   ];
   blockTemplate$: Observable<StoryBlock[]> = of(this.blockTemplates);
-  coordinates: Coordinate;
+
   constructor(private _logger: Logger, private dragService: DragDropService) {}
 
   ngOnInit(): void {
@@ -81,103 +78,6 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
     if (!this.frame || !this.frame.loaded)
       this._logger.warn(() => `Blocks library loaded yet frame not yet loaded.`);
     this.filterBlockTemplates();
-    this._sbS.sink = this.dragService.coord$.subscribe(position => this.coordinates = position)
-  }
-  addBlock(type: number, coordinates?: Coordinate) {
-    switch (type) {
-      case StoryBlockTypes.EndStoryAnchorBlock:
-        this.frame.newBlock(StoryBlockTypes.EndStoryAnchorBlock, coordinates);
-        break;
-      case StoryBlockTypes.TextMessage:
-        this.frame.newBlock(StoryBlockTypes.TextMessage, coordinates);
-        break;
-      case StoryBlockTypes.Input:
-        this.frame.newBlock(StoryBlockTypes.Input, coordinates);
-        break;
-      case StoryBlockTypes.IO:
-        this.frame.newBlock(StoryBlockTypes.IO, coordinates);
-        break;
-      case StoryBlockTypes.Location:
-        this.frame.newBlock(StoryBlockTypes.Location, coordinates);
-        break;
-      case StoryBlockTypes.Image:
-        this.frame.newBlock(StoryBlockTypes.Image, coordinates);
-        break;
-      case StoryBlockTypes.QuestionBlock:
-        this.frame.newBlock(StoryBlockTypes.QuestionBlock, coordinates);
-        break;
-      case StoryBlockTypes.Document:
-        this.frame.newBlock(StoryBlockTypes.Document, coordinates);
-        break;
-      case StoryBlockTypes.Audio:
-        this.frame.newBlock(StoryBlockTypes.Audio, coordinates);
-        break;
-      case StoryBlockTypes.Structural:
-        this.frame.newBlock(StoryBlockTypes.Structural, coordinates);
-        break
-      case StoryBlockTypes.Name:
-        this.frame.newBlock(StoryBlockTypes.Name, coordinates);
-        break
-      case StoryBlockTypes.Email:
-        this.frame.newBlock(StoryBlockTypes.Email, coordinates);
-        break;
-      case StoryBlockTypes.PhoneNumber:
-        this.frame.newBlock(StoryBlockTypes.PhoneNumber, coordinates);
-        break
-      case StoryBlockTypes.Video:
-        this.frame.newBlock(StoryBlockTypes.Video, coordinates);
-        break;
-      case StoryBlockTypes.Sticker:
-        this.frame.newBlock(StoryBlockTypes.Sticker, coordinates);
-        break;
-      case StoryBlockTypes.List:
-        this.frame.newBlock(StoryBlockTypes.List, coordinates);
-        break;
-      case StoryBlockTypes.Reply:
-        this.frame.newBlock(StoryBlockTypes.Reply, coordinates);
-        break;
-      case StoryBlockTypes.JumpBlock:
-        this.frame.newBlock(StoryBlockTypes.JumpBlock, coordinates);
-        break;
-      case StoryBlockTypes.MultipleInput:
-        this.frame.newBlock(StoryBlockTypes.MultipleInput, coordinates);
-        break;
-      case StoryBlockTypes.FailBlock:
-        this.frame.newBlock(StoryBlockTypes.FailBlock, coordinates);
-        break;
-      case StoryBlockTypes.ImageInput:
-        this.frame.newBlock(StoryBlockTypes.ImageInput, coordinates);
-        break;
-      case StoryBlockTypes.LocationInputBlock:
-        this.frame.newBlock(StoryBlockTypes.LocationInputBlock, coordinates);
-        break;
-      case StoryBlockTypes.AudioInput:
-        this.frame.newBlock(StoryBlockTypes.AudioInput, coordinates);
-        break;
-      case StoryBlockTypes.VideoInput:
-        this.frame.newBlock(StoryBlockTypes.VideoInput, coordinates);
-        break;
-      case StoryBlockTypes.WebhookBlock:
-        this.frame.newBlock(StoryBlockTypes.WebhookBlock, coordinates);
-        break;
-      case StoryBlockTypes.OpenEndedQuestion:
-        this.frame.newBlock(StoryBlockTypes.OpenEndedQuestion, coordinates);
-        break;
-      case StoryBlockTypes.MultiContentInput:
-        this.frame.newBlock(StoryBlockTypes.MultiContentInput, coordinates);
-        break;
-      case StoryBlockTypes.keyword:
-        this.frame.newBlock(StoryBlockTypes.keyword, coordinates);
-        break;
-      case StoryBlockTypes.Event:
-        this.frame.newBlock(StoryBlockTypes.Event, coordinates);
-        break;
-      case StoryBlockTypes.Assessment:
-        this.frame.newBlock(StoryBlockTypes.Assessment, coordinates);
-        break;
-      case StoryBlockTypes.Conditional:
-        this.frame.newBlock(StoryBlockTypes.Conditional, coordinates);
-    }
   }
 
   getBlockIcon(type: number) {
@@ -188,11 +88,9 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
   filterBlockTemplates() {
     this.blockTemplate$ = combineLatest([this.filterInput$$, this.blockTemplate$])
       .pipe(map(([filter, blocksArray]) => {
-        this.filteredBlocks = blocksArray.filter((block: StoryBlock) => {
+        return blocksArray.filter((block: StoryBlock) => {
           return block.message?.toString().toLowerCase().includes(filter);
         });
-  
-        return this.filteredBlocks;
       }));
   }
 
@@ -200,12 +98,7 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
     this.filterInput$$.next(event.target.value);
   }
 
-  onDragEnd(blockType: number){
-    this.addBlock(blockType, this.coordinates)
-  }
-
   ngOnDestroy() {
     this._sbS.unsubscribe();
   }
-
 }

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/blocks-library/blocks-library.component.ts
@@ -187,13 +187,12 @@ export class BlocksLibraryComponent implements OnInit, OnDestroy {
     this.blockTemplate$ = combineLatest([this.filterInput$$, this.blockTemplate$])
       .pipe(map(([filter, blocksArray]) => blocksArray
         .filter((block: StoryBlock) => {
-          return block.message?.toString().toLowerCase().includes(filter) || block.blockTitle?.toString().toLowerCase().includes(filter);
+          return block.message?.toString().toLowerCase().includes(filter)
         })))
   }
 
   filterBlocks(event: any) {
-    const searchTerm = event.target.value.toLowerCase();
-    this.filterInput$$.next(searchTerm);
+    this.filterInput$$.next(event.target.value);
   }
 
   onDragEnd(blockType: number){

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/grouped-blocks/grouped-blocks.component.html
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/grouped-blocks/grouped-blocks.component.html
@@ -1,0 +1,1 @@
+<p>grouped-blocks works!</p>

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/grouped-blocks/grouped-blocks.component.html
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/grouped-blocks/grouped-blocks.component.html
@@ -1,1 +1,13 @@
-<p>grouped-blocks works!</p>
+<div class="blocks">
+  <ng-container *ngFor="let block of groupedBlocks">
+    <div (click)="addBlock(block.type)" draggable="true" (dragend)="onDragEnd(block.type)" class="block">
+      <div fxLayout="column" fxLayoutAlign="center center" class="blocks-main">
+        <i class="{{ block.blockIcon }}" id="icons"></i>
+      </div>
+      <p class="block-messages">
+        {{ block.message }}
+      </p>
+    </div>
+  </ng-container>
+</div>
+

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/grouped-blocks/grouped-blocks.component.scss
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/grouped-blocks/grouped-blocks.component.scss
@@ -1,0 +1,37 @@
+.blocks {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 8px;
+
+  .blocks-main {
+    height: 60px;
+    border-radius: 5px;
+    word-wrap: break-word;
+    background-color: #fff;
+    box-shadow: 0px 10px -14px 14px #fff;
+  }
+
+  p {
+    padding: 0;
+    margin: 0;
+  }
+
+  .blocks-main:hover {
+    background-color: #fbc113 !important;
+
+    #icons {
+      color: white !important;
+    }
+  }
+
+  .block-messages {
+    font-size: 0.7rem;
+    text-align: center;
+    white-space: normal;
+    word-break: normal;
+    height: max-content;
+    font-weight: 500;
+    color: slategray;
+    margin: 0;
+  }
+}

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/grouped-blocks/grouped-blocks.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/grouped-blocks/grouped-blocks.component.ts
@@ -1,8 +1,137 @@
-import { Component } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
+
+import { SubSink } from 'subsink';
+
+import {
+  StoryBlock,
+  StoryBlockTypes,
+} from '@app/model/convs-mgr/stories/blocks/main';
+
+import { Coordinate } from '../../model/coordinates.interface';
+import { StoryEditorFrame } from '../../model/story-editor-frame.model';
+import { DragDropService } from '../../providers/drag-drop.service';
 
 @Component({
   selector: 'convl-grouped-blocks',
   templateUrl: './grouped-blocks.component.html',
   styleUrls: ['./grouped-blocks.component.scss'],
 })
-export class GroupedBlocksComponent {}
+export class GroupedBlocksComponent implements OnInit, OnDestroy {
+  @Input() groupedBlocks: StoryBlock[];
+  @Input() frame: StoryEditorFrame;
+
+  private _sBs = new SubSink();
+
+  coordinates: Coordinate;
+
+  constructor(private dragService: DragDropService) {}
+
+  ngOnInit() {
+    this._sBs.sink = this.dragService.coord$.subscribe((position) => (this.coordinates = position));
+  }
+
+  addBlock(type: number, coordinates?: Coordinate) {
+    switch (type) {
+      case StoryBlockTypes.EndStoryAnchorBlock:
+        this.frame.newBlock(StoryBlockTypes.EndStoryAnchorBlock, coordinates);
+        break;
+      case StoryBlockTypes.TextMessage:
+        this.frame.newBlock(StoryBlockTypes.TextMessage, coordinates);
+        break;
+      case StoryBlockTypes.Input:
+        this.frame.newBlock(StoryBlockTypes.Input, coordinates);
+        break;
+      case StoryBlockTypes.IO:
+        this.frame.newBlock(StoryBlockTypes.IO, coordinates);
+        break;
+      case StoryBlockTypes.Location:
+        this.frame.newBlock(StoryBlockTypes.Location, coordinates);
+        break;
+      case StoryBlockTypes.Image:
+        this.frame.newBlock(StoryBlockTypes.Image, coordinates);
+        break;
+      case StoryBlockTypes.QuestionBlock:
+        this.frame.newBlock(StoryBlockTypes.QuestionBlock, coordinates);
+        break;
+      case StoryBlockTypes.Document:
+        this.frame.newBlock(StoryBlockTypes.Document, coordinates);
+        break;
+      case StoryBlockTypes.Audio:
+        this.frame.newBlock(StoryBlockTypes.Audio, coordinates);
+        break;
+      case StoryBlockTypes.Structural:
+        this.frame.newBlock(StoryBlockTypes.Structural, coordinates);
+        break;
+      case StoryBlockTypes.Name:
+        this.frame.newBlock(StoryBlockTypes.Name, coordinates);
+        break;
+      case StoryBlockTypes.Email:
+        this.frame.newBlock(StoryBlockTypes.Email, coordinates);
+        break;
+      case StoryBlockTypes.PhoneNumber:
+        this.frame.newBlock(StoryBlockTypes.PhoneNumber, coordinates);
+        break;
+      case StoryBlockTypes.Video:
+        this.frame.newBlock(StoryBlockTypes.Video, coordinates);
+        break;
+      case StoryBlockTypes.Sticker:
+        this.frame.newBlock(StoryBlockTypes.Sticker, coordinates);
+        break;
+      case StoryBlockTypes.List:
+        this.frame.newBlock(StoryBlockTypes.List, coordinates);
+        break;
+      case StoryBlockTypes.Reply:
+        this.frame.newBlock(StoryBlockTypes.Reply, coordinates);
+        break;
+      case StoryBlockTypes.JumpBlock:
+        this.frame.newBlock(StoryBlockTypes.JumpBlock, coordinates);
+        break;
+      case StoryBlockTypes.MultipleInput:
+        this.frame.newBlock(StoryBlockTypes.MultipleInput, coordinates);
+        break;
+      case StoryBlockTypes.FailBlock:
+        this.frame.newBlock(StoryBlockTypes.FailBlock, coordinates);
+        break;
+      case StoryBlockTypes.ImageInput:
+        this.frame.newBlock(StoryBlockTypes.ImageInput, coordinates);
+        break;
+      case StoryBlockTypes.LocationInputBlock:
+        this.frame.newBlock(StoryBlockTypes.LocationInputBlock, coordinates);
+        break;
+      case StoryBlockTypes.AudioInput:
+        this.frame.newBlock(StoryBlockTypes.AudioInput, coordinates);
+        break;
+      case StoryBlockTypes.VideoInput:
+        this.frame.newBlock(StoryBlockTypes.VideoInput, coordinates);
+        break;
+      case StoryBlockTypes.WebhookBlock:
+        this.frame.newBlock(StoryBlockTypes.WebhookBlock, coordinates);
+        break;
+      case StoryBlockTypes.OpenEndedQuestion:
+        this.frame.newBlock(StoryBlockTypes.OpenEndedQuestion, coordinates);
+        break;
+      case StoryBlockTypes.MultiContentInput:
+        this.frame.newBlock(StoryBlockTypes.MultiContentInput, coordinates);
+        break;
+      case StoryBlockTypes.keyword:
+        this.frame.newBlock(StoryBlockTypes.keyword, coordinates);
+        break;
+      case StoryBlockTypes.Event:
+        this.frame.newBlock(StoryBlockTypes.Event, coordinates);
+        break;
+      case StoryBlockTypes.Assessment:
+        this.frame.newBlock(StoryBlockTypes.Assessment, coordinates);
+        break;
+      case StoryBlockTypes.Conditional:
+        this.frame.newBlock(StoryBlockTypes.Conditional, coordinates);
+    }
+  }
+
+  onDragEnd(blockType: number) {
+    this.addBlock(blockType, this.coordinates);
+  }
+
+  ngOnDestroy() {
+    this._sBs.unsubscribe();
+  }
+}

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/grouped-blocks/grouped-blocks.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/grouped-blocks/grouped-blocks.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'convl-grouped-blocks',
+  templateUrl: './grouped-blocks.component.html',
+  styleUrls: ['./grouped-blocks.component.scss'],
+})
+export class GroupedBlocksComponent {}

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/pipes/block-category-pipe.pipe.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/pipes/block-category-pipe.pipe.ts
@@ -1,12 +1,15 @@
 import { Pipe, PipeTransform } from '@angular/core';
+import { StoryBlock } from '@app/model/convs-mgr/stories/blocks/main';
 
 @Pipe({
   name: 'blockCategoryPipe'
 })
 export class BlockCategoryPipe implements PipeTransform {
 
-  transform(value: unknown, ...args: unknown[]): unknown {
-    return null;
-  }
-
+  transform(blocks: StoryBlock[], category: string, filter: string): boolean {
+     const filteredBlocks = blocks.filter((block: StoryBlock) => {
+      return block.blockCategory === category && block.message?.toString().toLowerCase().includes(filter);
+     })
+     return filteredBlocks.length > 0
+  }  
 }

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/pipes/block-category-pipe.pipe.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/pipes/block-category-pipe.pipe.ts
@@ -6,10 +6,11 @@ import { StoryBlock } from '@app/model/convs-mgr/stories/blocks/main';
 })
 export class BlockCategoryPipe implements PipeTransform {
 
-  transform(blocks: StoryBlock[], category: string, filter: string): boolean {
-     const filteredBlocks = blocks.filter((block: StoryBlock) => {
-      return block.blockCategory === category && block.message?.toString().toLowerCase().includes(filter);
-     })
-     return filteredBlocks.length > 0
-  }  
+  transform(blocks: StoryBlock[], category: string): StoryBlock[] {
+    const groupedBlocks = blocks.filter((block: StoryBlock) => {
+      return block.blockCategory === category;
+    });
+
+    return groupedBlocks
+  }
 }

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/pipes/block-category-pipe.pipe.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/pipes/block-category-pipe.pipe.ts
@@ -1,0 +1,12 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+  name: 'blockCategoryPipe'
+})
+export class BlockCategoryPipe implements PipeTransform {
+
+  transform(value: unknown, ...args: unknown[]): unknown {
+    return null;
+  }
+
+}

--- a/libs/features/convs-mgr/stories/editor/src/lib/convl-story-editor.module.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/convl-story-editor.module.ts
@@ -28,6 +28,8 @@ import { AddBotToChannelModal } from './modals/add-bot-to-channel-modal/add-bot-
 import { ConvlStoryEditorRouterModule } from './convs-story-editor.router.module';
 import { PinchZoomDirective } from './directives/app-pinch-zoom.directive';
 import { TrackCursorDirective } from './directives/track-cursor.directive';
+import { BlockCategoryPipe } from './components/pipes/block-category-pipe.pipe';
+
 
 @NgModule({
   imports: [
@@ -45,7 +47,8 @@ import { TrackCursorDirective } from './directives/track-cursor.directive';
     StoryEditorFrameComponent,
     BlocksLibraryComponent,
     PinchZoomDirective,
-    TrackCursorDirective
+    TrackCursorDirective,
+    BlockCategoryPipe,
   ],
 
   providers: [StoryEditorInitialiserService, ManageChannelStoryLinkService],

--- a/libs/features/convs-mgr/stories/editor/src/lib/convl-story-editor.module.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/convl-story-editor.module.ts
@@ -19,6 +19,7 @@ import { StoryEditorFrameComponent } from './components/editor-frame/editor-fram
 import { BlocksLibraryComponent } from './components/blocks-library/blocks-library.component';
 
 import { StoryEditorPageComponent } from './pages/story-editor/story-editor.page';
+import { GroupedBlocksComponent } from './components/grouped-blocks/grouped-blocks.component';
 
 import { StoryEditorInitialiserService } from './providers/story-editor-initialiser.service';
 import { ManageChannelStoryLinkService } from './providers/manage-channel-story-link.service';
@@ -28,6 +29,7 @@ import { AddBotToChannelModal } from './modals/add-bot-to-channel-modal/add-bot-
 import { ConvlStoryEditorRouterModule } from './convs-story-editor.router.module';
 import { PinchZoomDirective } from './directives/app-pinch-zoom.directive';
 import { TrackCursorDirective } from './directives/track-cursor.directive';
+
 import { BlockCategoryPipe } from './components/pipes/block-category-pipe.pipe';
 
 
@@ -45,6 +47,7 @@ import { BlockCategoryPipe } from './components/pipes/block-category-pipe.pipe';
     StoryEditorPageComponent,
     AddBotToChannelModal,
     StoryEditorFrameComponent,
+    GroupedBlocksComponent,
     BlocksLibraryComponent,
     PinchZoomDirective,
     TrackCursorDirective,


### PR DESCRIPTION
# Description
Before, when a user searched for a block, the block was filtered but the headings of other blocks were also showing below the relevant result. 
For this fix, I am suggesting that for a filter to fully match, both the heading and block texts have to match, thus returning only the relevant results for both the category and blocks under it.

Fixes #466 

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)


# Screenshot (optional
[Screencast from 28-06-23 16:18:58.webm](https://github.com/italanta/elewa/assets/109944021/01ea5ce1-5bf3-4c62-bb4a-bff27070aefb)
)



# How Has This Been Tested?
Only relevant results show on search.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

