### PR TITLE
🔢 🚚 Assessment View Page Metrics And Code Structure Update

### DIFF
--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.html
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.html
@@ -35,12 +35,12 @@
                 
                     <ng-container matColumnDef="inProgress">
                         <th class="table-header" mat-header-cell *matHeaderCellDef mat-sort-header="inProgress" sortActionDescription="{{'ASSESSMENTS.ACCESSIBILITY.SORT-BY-IN-PROGRESS' | transloco}}">{{'ASSESSMENTS.TABLE-HEADER.IN-PROGRESS' | transloco}}</th>
-                        <td mat-cell *matCellDef="let assessment">10</td>
+                        <td mat-cell *matCellDef="let assessment">{{ assessment?.metrics?.inProgress }}</td>
                     </ng-container>
                 
                     <ng-container matColumnDef="responses">
                         <th class="table-header" mat-header-cell *matHeaderCellDef mat-sort-header="responses" sortActionDescription="{{'ASSESSMENTS.ACCESSIBILITY.SORT-BY-RESPONSES' | transloco}}">{{'ASSESSMENTS.TABLE-HEADER.RESPONSES' | transloco}}</th>
-                        <td mat-cell *matCellDef>48</td>
+                        <td mat-cell *matCellDef="let assessment">{{ assessment?.metrics?.completedRes }}</td>
                     </ng-container>
                 
                     <ng-container matColumnDef="actions">

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.ts
@@ -17,7 +17,7 @@ import { AssessmentService } from '@app/state/convs-mgr/conversations/assessment
 import { CreateAssessmentModalComponent } from '../../modals/create-assessment-modal/create-assessment-modal.component';
 import { DeleteAssessmentModalComponent } from '../../modals/delete-assessment-modal/delete-assessment-modal.component';
 import { AssessmentDataSource } from '../../data-source/assessment-data-source.class';
-import { AssessmentMetricsService } from '../../services/assessment-details.service';
+import { AssessmentMetricsService } from '../../services/assessment-metrics.service';
 
 
 @Component({

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.ts
@@ -6,12 +6,12 @@ import { MatDialog } from '@angular/material/dialog';
 import { MatSort, Sort } from '@angular/material/sort';
 
 import { SubSink } from 'subsink';
-import { Observable, map, switchMap, tap } from 'rxjs';
+import { Observable, map, switchMap } from 'rxjs';
 import { TranslateService } from '@ngfi/multi-lang';
 import { __DateFromStorage } from '@iote/time';
 
 import { Assessment } from '@app/model/convs-mgr/conversations/assessments';
-import { EndUserDetails, EndUserService } from '@app/state/convs-mgr/end-users';
+import { EndUserService } from '@app/state/convs-mgr/end-users';
 import { AssessmentService } from '@app/state/convs-mgr/conversations/assessments';
 
 import { CreateAssessmentModalComponent } from '../../modals/create-assessment-modal/create-assessment-modal.component';
@@ -75,22 +75,6 @@ export class AssessmentListComponent implements OnInit, OnDestroy {
         })
       )
       .subscribe();
-  }
-
-  computeMetrics(endUsers: EndUserDetails[], assessment: Assessment) {
-    let inProgress = 0;
-    let completedRes = 0;
-
-    endUsers.map((user) => {
-      if (!user.cursor[0].assessmentStack) return;
-
-      const assessExists = user.cursor[0].assessmentStack.find((assess) => assess.assessmentId === assessment.id);
-
-      if (!assessExists) return 
-      assessExists.finishedOn ? completedRes += 1 : inProgress += 1
-    });
-
-    return { inProgress, completedRes }
   }
 
   openAssessment(assessmentId: string) {

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.ts
@@ -17,6 +17,7 @@ import { AssessmentService } from '@app/state/convs-mgr/conversations/assessment
 import { CreateAssessmentModalComponent } from '../../modals/create-assessment-modal/create-assessment-modal.component';
 import { DeleteAssessmentModalComponent } from '../../modals/delete-assessment-modal/delete-assessment-modal.component';
 import { AssessmentDataSource } from '../../data-source/assessment-data-source.class';
+import { AssessmentMetricsService } from '../../services/assessment-details.service';
 
 
 @Component({
@@ -44,6 +45,7 @@ export class AssessmentListComponent implements OnInit, OnDestroy {
   }
 
   constructor(
+    private _aMetrics: AssessmentMetricsService,
     private _assessments: AssessmentService,
     private _endUserService: EndUserService,
     private _dialog: MatDialog,
@@ -66,7 +68,7 @@ export class AssessmentListComponent implements OnInit, OnDestroy {
           return this._assessments.getAssessments$().pipe(
             map((assessments) => {
               return assessments.map((assessment) => {
-                return (assessment.metrics = this.computeMetrics(endUsers,assessment));
+                return (assessment.metrics = this._aMetrics.computeMetrics(endUsers,assessment).assessmentMetrics);
               });
             })
           );

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/pages/assessment-results/assessment-results.component.html
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/pages/assessment-results/assessment-results.component.html
@@ -2,7 +2,7 @@
   <div class="page-container">
     <div class="title-wrapper">
       <button class="btn btn__back" (click)="goBack()">{{ 'ASSESSMENTS.RESULTS.BUTTONS.GO-BACK' | transloco }}</button>
-      <button class="btn btn__edit">
+      <button class="btn btn__edit" (click)="edit()">
         <mat-icon>edit</mat-icon>
         <span>{{ 'ASSESSMENTS.RESULTS.BUTTONS.EDIT ASSESSMENT' | transloco }}</span>
       </button>

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/pages/assessment-results/assessment-results.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/pages/assessment-results/assessment-results.component.scss
@@ -7,7 +7,7 @@
     place-content: center;
 
     .chart {
-      width: 24vw;
+      width: 23vw;
       height: auto;
       margin-top: -2rem;
     }

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/pages/assessment-results/assessment-results.component.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/pages/assessment-results/assessment-results.component.ts
@@ -135,7 +135,7 @@ export class AssessmentResultsComponent implements OnInit, OnDestroy {
     return new Chart('chart-ctx', {
       type: 'doughnut',
       data: {
-        labels: ['No Data Available'],
+        labels: ['No Metrics Available'],
         datasets: [{
           data: [100],
           backgroundColor: ['rgba(128, 128, 128, 1)'],

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/pages/assessment-results/assessment-results.component.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/pages/assessment-results/assessment-results.component.ts
@@ -17,6 +17,7 @@ import { EndUserDetails } from '@app/state/convs-mgr/end-users';
 import { ActiveAssessmentStore, AssessmentQuestionService } from '@app/state/convs-mgr/conversations/assessments';
 
 import { AssessmentMetricsService } from '../../services/assessment-metrics.service';
+import { pieChartOptions } from '../../utils/chart.util';
 
 @Component({
   selector: 'app-assessment-results',
@@ -103,9 +104,12 @@ export class AssessmentResultsComponent implements OnInit, OnDestroy {
   private _loadChart(chartData: number[]) {
     // don't generate graph if no data is present
     const isData = chartData.find(score => score > 1)
-    if (!isData) return;
 
     if (this.chart) this.chart.destroy();
+
+    if (!isData) {
+      return this._drawEmptyChart();
+    };
 
     return new Chart('chart-ctx', {
       type: 'pie',
@@ -123,33 +127,23 @@ export class AssessmentResultsComponent implements OnInit, OnDestroy {
           hoverOffset: 4
         }]
       },
-      options: {
-        maintainAspectRatio: false,
-        responsive: true,
-        normalized: true,
-        plugins: {
-          legend: {
-            position: 'right',
-            labels : {
-              usePointStyle: true,
-              padding: 25,
-            }
-          },
-          tooltip: {
-            callbacks: {
-              label(context) {
-                const sum = context.dataset.data.reduce((sum, value) => sum + value);
-
-                const value = context.raw as number;
-                const percentage = Math.round((value / sum) * 100);
-  
-                return `learners ${value} (${percentage}%)`;
-              }
-            }
-          }
-        },
-      },
+      options: pieChartOptions
     });
+  }
+
+  private _drawEmptyChart() {
+    return new Chart('chart-ctx', {
+      type: 'doughnut',
+      data: {
+        labels: ['No Data Available'],
+        datasets: [{
+          data: [100],
+          backgroundColor: ['rgba(128, 128, 128, 1)'],
+          hoverOffset: 4
+        }]
+      },
+      options: pieChartOptions
+    })
   }
 
   computeScores(scores:number[]) {

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/pages/assessment-results/assessment-results.component.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/pages/assessment-results/assessment-results.component.ts
@@ -241,6 +241,10 @@ export class AssessmentResultsComponent implements OnInit, OnDestroy {
     this._router.navigate(['/assessments'])
   }
 
+  edit() {
+    this._router.navigate(['/assessments', this.assessment.id], { queryParams: { mode: 'edit' }})
+  }
+
   ngOnDestroy() {
     this._sBs.unsubscribe();
     this.chart?.destroy();

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/pages/assessment-results/assessment-results.component.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/pages/assessment-results/assessment-results.component.ts
@@ -16,7 +16,7 @@ import { EndUserService } from '@app/state/convs-mgr/end-users';
 import { EndUserDetails } from '@app/state/convs-mgr/end-users';
 import { ActiveAssessmentStore, AssessmentQuestionService } from '@app/state/convs-mgr/conversations/assessments';
 
-import { AssessmentMetricsService } from '../../services/assessment-details.service';
+import { AssessmentMetricsService } from '../../services/assessment-metrics.service';
 
 @Component({
   selector: 'app-assessment-results',
@@ -34,11 +34,9 @@ export class AssessmentResultsComponent implements OnInit, OnDestroy {
   assessmentResults = ['index', 'name', 'phone', 'startedOn', 'finishedOn', 'score', 'scoreCategory'];
   pageTitle: string;
 
-  scores: number[] = [];
   highestScore: number;
   lowestScore: number;
   averageScore: number | string;
-
   totalQuestions: number;
 
   @ViewChild(MatSort) sort: MatSort;
@@ -69,10 +67,10 @@ export class AssessmentResultsComponent implements OnInit, OnDestroy {
 
           return this._endUserService.getUserDetailsAndTheirCursor().pipe(
             map((endUsers) => {
-              const { data, chartData } = this._aMetrics.computeMetrics(endUsers,assessment);
+              const { data, chartData, scores } = this._aMetrics.computeMetrics(endUsers,assessment);
               this.itemsLength = data.length;
               this.initDataSource(data);
-              this.computeScores();
+              this.computeScores(scores);
               this._loadChart(chartData);
             })
           );
@@ -154,14 +152,14 @@ export class AssessmentResultsComponent implements OnInit, OnDestroy {
     });
   }
 
-  computeScores() {
-    if (!this.scores.length) return;
+  computeScores(scores:number[]) {
+    if (!scores.length) return;
 
-    this.highestScore = Math.max(...this.scores);
-    this.lowestScore = Math.min(...this.scores);
+    this.highestScore = Math.max(...scores);
+    this.lowestScore = Math.min(...scores);
 
-    const sum = this.scores.reduce((prev, next) => prev + next);
-    this.averageScore = (sum/this.scores.length).toFixed(2);
+    const sum = scores.reduce((prev, next) => prev + next);
+    this.averageScore = (sum/scores.length).toFixed(2);
   };
 
   sortData(sortState: Sort) {

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/pages/assessment-results/assessment-results.component.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/pages/assessment-results/assessment-results.component.ts
@@ -147,6 +147,7 @@ export class AssessmentResultsComponent implements OnInit, OnDestroy {
     });
   }
 
+  /** Returns a list of users that have attempted the assessment */
   filterData(results: EndUserDetails[]) {
     const data = results.filter(user => {
       if (!user.cursor[0].assessmentStack) return false

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/pages/assessment-view/assessment-view.component.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/pages/assessment-view/assessment-view.component.ts
@@ -1,4 +1,5 @@
 import { Component, OnDestroy, OnInit } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { FormGroup } from '@angular/forms';
 import { MatSnackBar } from '@angular/material/snack-bar';
 
@@ -43,7 +44,8 @@ export class AssessmentViewComponent implements OnInit, OnDestroy
     private _assessmentForm: AssessmentFormService,
     private _assessmentQuestion: AssessmentQuestionService,
     private _assessToggle: AssessToggleStateService,
-    private _snackBar: MatSnackBar
+    private _snackBar: MatSnackBar, 
+    private _route:ActivatedRoute
   ) {}
 
   ngOnInit(): void
@@ -58,7 +60,17 @@ export class AssessmentViewComponent implements OnInit, OnDestroy
     this.assessment$ = this._assessmentService.getActiveAssessment$();
     this.questions$ = this._assessmentQuestion.getQuestions$();
     this.preloadQuestions();
-    this.assessmentMode = AssessmentMode.View;
+
+    this._sbS.sink = this._route.queryParamMap.subscribe(params => {
+      const mode = params.get('mode');
+
+      if (mode === 'edit') {
+        this.assessmentMode = AssessmentMode.Edit;
+        this._assessToggle.hidePublish();
+      } else {
+        this.assessmentMode = AssessmentMode.View;
+      }
+    });
   }
 
   initPage()

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/services/assessment-metrics.service.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/services/assessment-metrics.service.ts
@@ -1,0 +1,82 @@
+import { Injectable } from '@angular/core';
+
+import { EndUserDetails } from '@app/state/convs-mgr/end-users';
+
+import { Assessment } from '@app/model/convs-mgr/conversations/assessments';
+import { AssessmentCursor } from '@app/model/convs-mgr/conversations/admin/system';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AssessmentMetricsService {
+
+  passedCount = 0;
+  failedCount = 0;
+  averageCount = 0;
+  inProgressCount = 0;
+  belowAverageCount = 0;
+  scores:number[] = [];
+
+  /** Returns a list of users that have attempted the assessment */
+  computeMetrics(endUsers: EndUserDetails[], assessment: Assessment) {
+    this._resetMetrics();
+    
+    const data = endUsers.filter((user) => {
+      if (!user.cursor[0].assessmentStack) return false;
+
+      const assessExists = user.cursor[0].assessmentStack.find((assess) => assess.assessmentId === assessment.id);
+
+      if (assessExists) {
+        user.scoreCategory = this._getScoreCategory(assessExists);
+        user.selectedAssessmentCursor = assessExists;
+        this.scores.push(assessExists.score);
+        return true;
+      }
+
+      else return false;
+    });
+
+    return {
+      data,
+      assessmentMetrics: {
+        inProgress: this.inProgressCount,
+        completedRes: (this.averageCount + this.belowAverageCount + this.failedCount + this.passedCount) 
+      },
+      chartData: [this.passedCount, this.averageCount, this.inProgressCount, this.belowAverageCount, this.failedCount]
+    };
+  }
+
+  /** Get the score category of a user and compute the necessary values */
+  private _getScoreCategory(assessmentCursor: AssessmentCursor) {
+    if (!assessmentCursor.finishedOn) {
+      this.inProgressCount++
+      return 'In progress'
+    }
+
+    const finalScore = assessmentCursor.score;
+    const finalPercentage = (assessmentCursor.maxScore == 0 ? 0 : (finalScore/assessmentCursor.maxScore)) * 100;
+
+    if (finalPercentage >= 0 && finalPercentage < 34) {
+      this.failedCount++
+      return 'Failed';
+    } else if (finalPercentage >= 50 && finalPercentage <= 75) {
+      this.averageCount++
+      return 'Average';
+    } else if (finalPercentage >= 35 && finalPercentage <= 49) {
+      this.belowAverageCount++
+      return 'Below Average'
+    } else {
+      this.passedCount++
+      return 'Pass';
+    }
+  }
+
+  /** Reset values back to zero - we do this on every calculation */
+  private _resetMetrics() {
+    this.passedCount = 0;
+    this.failedCount = 0;
+    this.averageCount = 0;
+    this.inProgressCount = 0;
+    this.belowAverageCount = 0;
+  }
+}

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/services/assessment-metrics.service.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/services/assessment-metrics.service.ts
@@ -38,6 +38,7 @@ export class AssessmentMetricsService {
 
     return {
       data,
+      scores: this.scores,
       assessmentMetrics: {
         inProgress: this.inProgressCount,
         completedRes: (this.averageCount + this.belowAverageCount + this.failedCount + this.passedCount) 
@@ -78,5 +79,6 @@ export class AssessmentMetricsService {
     this.averageCount = 0;
     this.inProgressCount = 0;
     this.belowAverageCount = 0;
+    this.scores = []
   }
 }

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/utils/chart.util.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/utils/chart.util.ts
@@ -1,0 +1,29 @@
+import { ChartOptions, TooltipItem } from "chart.js";
+
+export const pieChartOptions = {
+  maintainAspectRatio: false,
+  responsive: true,
+  normalized: true,
+  plugins: {
+    legend: {
+      position: 'right',
+      labels : {
+        usePointStyle: true,
+        padding: 25,
+      }
+    },
+    tooltip: {
+      callbacks: {
+        label(context:TooltipItem<"pie">) {
+          const sum = context.dataset.data.reduce((sum, value) => sum + value);
+
+          const value = context.raw as number;
+          const percentage = Math.round((value / sum) * 100);
+
+          return `learners ${value} (${percentage}%)`;
+        }
+      }
+    }
+  },
+} as ChartOptions<'pie' | 'doughnut'>
+

--- a/libs/model/convs-mgr/conversations/assessments/src/lib/assessment.interface.ts
+++ b/libs/model/convs-mgr/conversations/assessments/src/lib/assessment.interface.ts
@@ -9,6 +9,12 @@ export interface Assessment extends Story {
 
     /** Differentiate between published assessment and non published ones */
     isPublished?: boolean
+    metrics?: AssessmentMetrics
+}
+
+export interface AssessmentMetrics {
+    inProgress: number,
+    completedRes?: number
 }
 
 export interface AssessmentConfiguration{


### PR DESCRIPTION
# Description
This PR computes metrics on the assessment view page and also does the following:
-  moves all metrics calculations to a shared service.
-  refactors the edit route functionality on the assessment results page (we now get the mode from queryParams on the assessment view page).
- Generates an empty chart when all values are zero.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] I have performed a self-review of my code
- [x] My code follows the style guidelines of this project
- [x] I have commented on my code, particularly in hard-to-understand areas
