### PR TITLE
⚡ 📹  Upload media to whatsapp on publish

### DIFF
--- a/apps/conv-lm-backend/src/app/bot/whatsapp-channel/whatsapp-upload-media.function.ts
+++ b/apps/conv-lm-backend/src/app/bot/whatsapp-channel/whatsapp-upload-media.function.ts
@@ -1,0 +1,24 @@
+import { EndpointRegistrar } from "@ngfi/functions";
+
+import { WhatsAppUploadMediaHandler } from "@app/functions/bot-engine/whatsapp";
+
+import { ConvLearnFunction } from "../../../conv-learn-func.class";
+
+
+const handler = new WhatsAppUploadMediaHandler();
+
+/**
+ * @Description : When an end user sends a message to the chatbot, this function is triggered, 
+ *      handles the message and potentially responds to it
+ * 
+ * It is specifically for Whatsapp @see {PlatformType}, and subscribes to the 'messages' webhook on
+ *      the Meta Developers platform
+ * 
+ * @see https://developers.facebook.com/docs/whatsapp/cloud-api/guides/set-up-webhooks
+ * 
+ */
+export const channelWhatsappUploadMedia = new ConvLearnFunction('channelWhatsappUploadMedia', 
+                                                  new EndpointRegistrar(), 
+                                                  [], 
+                                                  handler)
+                               .build();

--- a/apps/conv-lm-backend/src/main.ts
+++ b/apps/conv-lm-backend/src/main.ts
@@ -6,6 +6,8 @@ const conf = config().firebase;
 admin.initializeApp(conf);
 
 export * from './app/bot/whatsapp-channel/whatsapp-receive-incoming-message.function';
+export * from './app/bot/whatsapp-channel/whatsapp-upload-media.function';
+
 export * from './app/bot/main/send-outgoing-message.function';
 export * from './app/bot/main/talk-to-human.function';
 export * from './app/bot/main/move-chat.function';

--- a/libs/functions/bot-engine/main/src/index.ts
+++ b/libs/functions/bot-engine/main/src/index.ts
@@ -19,5 +19,7 @@ export * from './lib/handlers/move-chat.handler';
 export * from './lib/services/data-services/cursor.service';
 export * from './lib/services/data-services/variables.service';
 export * from './lib/services/data-services/data-service-abstract.class';
+export * from './lib/services/data-services/blocks.service';
+export * from './lib/services/data-services/connections.service';
 export * from './lib/services/data-services/channel-info.service';
 export * from './lib/services/variable-injection/mail-merge-variables.service';

--- a/libs/functions/bot-engine/main/src/lib/services/bot-engine-play.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/bot-engine-play.service.ts
@@ -80,9 +80,9 @@ export class BotEnginePlay implements IBotEnginePlay
 
     // If the last block sent was media, we wait for 500ms 
     //  before replying as media processing can take a while
-    if(this.blockSent && isMediaBlock(this.blockSent.type) && !isMediaBlock(nextBlock.type)) {
-      await new Promise(resolve => setTimeout(resolve, 1500));
-    } 
+    // if(this.blockSent && isMediaBlock(this.blockSent.type) && !isMediaBlock(nextBlock.type)) {
+    //   await new Promise(resolve => setTimeout(resolve, 1500));
+    // } 
 
     await this.__reply(nextBlock, endUser, message);
 

--- a/libs/functions/bot-engine/main/src/lib/services/data-services/blocks.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/data-services/blocks.service.ts
@@ -55,17 +55,24 @@ export class BlockDataService extends BotDataService<StoryBlock> {
     return firstBlock;
   }
 
-  async getAllMediaBlocks(orgId: string, storyId: string): Promise<StoryBlock[]> {
+  async getAllMediaBlocks(orgId: string, storyId: string) {
 
     let jumpBlocks: JumpBlock[] = [];
-    let mediaBlocks: StoryBlock[] = [];
+    let mediaBlocks: any[] = [];
     let allBlocks: StoryBlock[] = [];
 
     this._docPath = `orgs/${orgId}/stories/${storyId}/blocks`;
 
     allBlocks = await this.getDocuments(this._docPath)
 
-    mediaBlocks = allBlocks.filter(block => isMediaBlock(block.type) && block.deleted !== true);
+    mediaBlocks = allBlocks
+                      .filter(block => isMediaBlock(block.type) && block.deleted !== true)
+                        .map(block => {
+                          return {
+                            data: block,
+                            storyId: storyId
+                          }
+                        });
 
     jumpBlocks = allBlocks.filter(block => block.type === StoryBlockTypes.JumpBlock && block.deleted !== true);
 
@@ -93,7 +100,14 @@ export class BlockDataService extends BotDataService<StoryBlock> {
 
         // Filter out jump blocks and media blocks in the linked story
         const newJumpBlocks = linkedStoryBlocks.filter(block => this.__filterJumpBlocks(block, processedJumpBlockIds));
-        const newMediaBlocks = linkedStoryBlocks.filter(block => isMediaBlock(block.type) && block.deleted !== true);
+        const newMediaBlocks = linkedStoryBlocks
+                                .filter(block => isMediaBlock(block.type) && block.deleted !== true)
+                                    .map(block => {
+                                      return {
+                                        data: block,
+                                        storyId: jumpBlock.targetStoryId
+                                      }
+                                    });
 
         this.tools.Logger.log(() => `New Jump Blocks: ${newJumpBlocks.length}`);
         this.tools.Logger.log(() => `Old Jump Blocks: ${jumpBlocks.length}`);

--- a/libs/functions/bot-engine/main/src/lib/services/data-services/blocks.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/data-services/blocks.service.ts
@@ -1,6 +1,6 @@
 import { HandlerTools } from '@iote/cqrs';
 
-import { StoryBlock } from '@app/model/convs-mgr/stories/blocks/main';
+import { StoryBlock, isMediaBlock } from '@app/model/convs-mgr/stories/blocks/main';
 import { CommunicationChannel } from '@app/model/convs-mgr/conversations/admin/system';
 
 import { BotDataService } from './data-service-abstract.class';
@@ -52,5 +52,23 @@ export class BlockDataService extends BotDataService<StoryBlock> {
     const firstBlock = await this.getBlockById(firstConnection.targetId, orgId,storyId);
 
     return firstBlock;
+  }
+
+  async getAllMediaBlocks(orgId: string, storyId: string): Promise<StoryBlock[]> {
+    this._docPath = `orgs/${orgId}/stories/${storyId}/blocks`;
+
+    const mediaBlocks = (await this.getDocuments(this._docPath))
+                          .filter(block => isMediaBlock(block.type));
+
+    // TODO: Consider media blocks of child stories
+    // Can follow the jump blocks on this
+
+    return mediaBlocks;
+  }
+
+  async updateBlock(orgId: string, storyId: string, block: StoryBlock): Promise<StoryBlock> {
+    this._docPath = `orgs/${orgId}/stories/${storyId}/blocks`;
+
+    return this.updateDocument(block, this._docPath);
   }
 }

--- a/libs/functions/bot-engine/whatsapp/src/index.ts
+++ b/libs/functions/bot-engine/whatsapp/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/whats-app-receive-message.handler';
 export * from './lib/whatsapp-send-message.handler';
 export * from './lib/models/whatsapp-active-channel.model';
+export * from './lib/whats-app-upload-media.handler';

--- a/libs/functions/bot-engine/whatsapp/src/lib/io/outgoing-message-parser/whatsapp-api-outgoing-message-parser.class.ts
+++ b/libs/functions/bot-engine/whatsapp/src/lib/io/outgoing-message-parser/whatsapp-api-outgoing-message-parser.class.ts
@@ -168,13 +168,20 @@ export class WhatsappOutgoingMessageParser extends OutgoingMessageParser
   {
     const imageBlock = storyBlock as ImageMessageBlock;
 
+    const imagePayload = {
+      caption: imageBlock.message || "",
+    }
+
+    if (imageBlock.whatsappMediaId) { 
+      imagePayload['id'] = imageBlock.whatsappMediaId;
+    } else {
+      imagePayload['link'] = imageBlock.fileSrc;
+    }
+
     // Create the image payload which will be sent to api
     const mediaMessage = {
       type: WhatsAppMessageType.IMAGE,
-      image: {
-        caption: imageBlock.message || "",
-        link: imageBlock.fileSrc,
-      },
+      image: imagePayload,
     } as WhatsAppImageMessage;
 
     /**
@@ -195,12 +202,18 @@ export class WhatsappOutgoingMessageParser extends OutgoingMessageParser
   {
     const audioBlock = storyBlock as VoiceMessageBlock;
 
+    const audioPayload = {};
+
+    if (audioBlock.whatsappMediaId) { 
+      audioPayload['id'] = audioBlock.whatsappMediaId;
+    } else {
+      audioPayload['link'] = audioBlock.fileSrc;
+    }
+
     // Create the text payload which will be sent to api
     const mediaMessage = {
       type: WhatsAppMessageType.AUDIO,
-      audio: {
-        link: audioBlock.fileSrc,
-      },
+      audio: audioPayload
     } as WhatsAppAudioMessage;
 
     /**
@@ -221,13 +234,20 @@ export class WhatsappOutgoingMessageParser extends OutgoingMessageParser
   {
     const videoBlock = storyBlock as VideoMessageBlock;
 
+    const videoPayload = {
+      caption: videoBlock.message || "",
+    }
+
+    if (videoBlock.whatsappMediaId) { 
+      videoPayload['id'] = videoBlock.whatsappMediaId;
+    } else {
+      videoPayload['link'] = videoBlock.fileSrc;
+    }
+
     // Create the text payload which will be sent to api
     const mediaMessage = {
       type: WhatsAppMessageType.VIDEO,
-      video: {
-        caption: videoBlock.message || "",
-        link: videoBlock.fileSrc,
-      },
+      video: videoPayload,
     } as WhatsAppVideoMessage;
 
     /**

--- a/libs/functions/bot-engine/whatsapp/src/lib/whats-app-upload-media.handler.ts
+++ b/libs/functions/bot-engine/whatsapp/src/lib/whats-app-upload-media.handler.ts
@@ -1,0 +1,150 @@
+import axios from 'axios'
+import * as path from 'path';
+import * as fs from 'fs';
+import { tmpdir } from 'os';
+import * as mime from 'mime-types';
+import * as FormData from 'form-data';
+
+import { HandlerTools } from '@iote/cqrs';
+import { FunctionHandler, RestResult, HttpsContext } from '@ngfi/functions';
+
+import { FileMessageBlock } from '@app/model/convs-mgr/stories/blocks/messaging';
+import { ConnectionsDataService, BlockDataService } from '@app/functions/bot-engine';
+import { CommunicationChannel, WhatsAppCommunicationChannel } from '@app/model/convs-mgr/conversations/admin/system';
+
+import { __ConvertWhatsAppApiPayload } from './utils/convert-whatsapp-payload.util';
+import { __SendWhatsAppWebhookVerificationToken } from './utils/validate-webhook.function';
+
+/**
+ * Receives a message, through a channel registered on the WhatsApp Business API,
+ *    handles it, and potentially responds to it.
+ */
+export class WhatsAppUploadMediaHandler extends FunctionHandler<CommunicationChannel, RestResult>
+{
+  channel: WhatsAppCommunicationChannel;
+  _tools: HandlerTools;
+
+  public async execute(payload: CommunicationChannel, context: HttpsContext, tools: HandlerTools) 
+  {
+    this._tools = tools;
+    this.channel = payload as WhatsAppCommunicationChannel;
+
+    this._tools.Logger.log(()=> `[WhatsApp Upload Media Handler] - Uploading media for Story: ${this.channel.defaultStory}`);
+
+    const connDataService = new ConnectionsDataService(this.channel, tools);
+    const blockDataService = new BlockDataService(this.channel, connDataService, this._tools);
+
+    const mediaBlocks = (await blockDataService.getAllMediaBlocks(this.channel.orgId, this.channel.defaultStory)) as FileMessageBlock[];
+
+    for(const block of mediaBlocks)
+    
+    {
+      if(block.fileSrc)
+      {
+        const filename = await this._downloadFromFirebaseURL(block.fileSrc);
+
+        const mediaId = await this._uploadMediaToWhatsApp(this.channel, filename);
+
+        if(mediaId) {
+          block.whatsappMediaId = mediaId;
+
+          await blockDataService.updateBlock(this.channel.orgId, this.channel.defaultStory, block);
+
+          this._tools.Logger.log(()=> `Block ${block.id} updated with Media ID: ${mediaId}`);
+        }
+      }
+    }
+
+    return {status: 200} as RestResult;
+  }
+
+  /**
+   * Method which checks if the whatsapp data object is empty.
+   *  This means the webhook has not yet been verified. */
+  private _dataResIsEmpty(data) 
+  {
+    return Object.keys(data).length === 0;
+  }
+
+  /**
+   * Fetches the media file, saves it to /tmp directory on the cloud function then returns the file path
+   * @param URL 
+   * @param mime_type - allows us to get the extension of the file
+   * @returns filePath and fileName
+   */
+  private async _downloadFromFirebaseURL(URL: string)
+  {
+    let extension: string;
+    try {
+      const response = await axios.get(URL, {
+        responseType: 'arraybuffer',
+      });
+  
+      const basename = path.basename(URL);
+      
+      const extname = path.extname(basename);
+
+      if(extname.includes('?')) {
+        extension = extname.split('?')[0];
+      } else {
+        extension = extname.split('_')[0];
+      }
+
+      const filename = `${Date.now()}${extension}`
+
+      const tempFilePath = path.join(tmpdir(), (filename));
+  
+      // Save the downloaded file or perform other operations
+      // For example, you can use fs.writeFile to save the file to disk:
+      fs.writeFile(tempFilePath, response.data, (error) => {
+        if (error) {
+          this._tools.Logger.error(()=> `Error saving file: ${error}`);
+        } else {
+          this._tools.Logger.log(()=> `File saved: ${tempFilePath}`);
+          return tempFilePath;
+        }
+      });
+      return tempFilePath;
+    } catch (error) {
+      this._tools.Logger.error(()=> `Error downloading file: ${error}`);
+    }
+  }
+
+  private async _uploadMediaToWhatsApp(channel: WhatsAppCommunicationChannel, filepath: string) {
+    
+    this._tools.Logger.log(()=> `Uploading file to Whatsapp Servers: ${filepath}`);
+
+    const URL = `https://graph.facebook.com/v17.0/${channel.id}/media`;
+
+    const type = mime.lookup(filepath) as string;
+
+    const messagingProduct = 'whatsapp';
+
+    try {
+
+      const formData = new FormData();
+
+      const rawData = fs.createReadStream(filepath)
+      formData.append('file', rawData);
+      formData.append('type', type);
+      formData.append('messaging_product', messagingProduct);
+  
+      const response = await axios.post(
+        URL,
+        formData,
+        {
+          headers: {
+            'Authorization': `Bearer ${channel.accessToken}`,
+            "Content-Type": "multipart/form-data"
+          },
+        }
+      );
+
+      return response.data.id;
+    } catch (error) {
+      this._tools.Logger.error(() => `Error uploading file: ${JSON.stringify(error)}`)
+      return null;
+    }
+
+  }
+}

--- a/libs/functions/bot-engine/whatsapp/src/lib/whats-app-upload-media.handler.ts
+++ b/libs/functions/bot-engine/whatsapp/src/lib/whats-app-upload-media.handler.ts
@@ -33,7 +33,7 @@ export class WhatsAppUploadMediaHandler extends FunctionHandler<CommunicationCha
   {
     this._tools = tools;
     this.channel = payload as WhatsAppCommunicationChannel;
-    const storyPublishedTime = __DateFromStorage(await this.__getStoryPublishedDate(this.channel.orgId, this.channel.defaultStory));
+    // const storyPublishedTime = __DateFromStorage(await this.__getStoryPublishedDate(this.channel.orgId, this.channel.defaultStory));
 
     this._tools.Logger.log(()=> `[WhatsApp Upload Media Handler] - Uploading media for Story: ${this.channel.defaultStory}`);
 
@@ -47,10 +47,10 @@ export class WhatsAppUploadMediaHandler extends FunctionHandler<CommunicationCha
     for(const block of mediaBlocks)
     {
       // Get block updated time
-      const blockUpdatedTime = __DateFromStorage(block.updatedOn);
+      // const blockUpdatedTime = __DateFromStorage(block.updatedOn);
 
       // Only upload media if the block was updated after the story was published
-      
+
       // TODO: Uncomment this when the storyPublishedTime is fixed
       // if(storyPublishedTime && blockUpdatedTime > storyPublishedTime) {
 

--- a/libs/functions/bot-engine/whatsapp/src/lib/whats-app-upload-media.handler.ts
+++ b/libs/functions/bot-engine/whatsapp/src/lib/whats-app-upload-media.handler.ts
@@ -50,7 +50,9 @@ export class WhatsAppUploadMediaHandler extends FunctionHandler<CommunicationCha
       const blockUpdatedTime = __DateFromStorage(block.updatedOn);
 
       // Only upload media if the block was updated after the story was published
-      if(storyPublishedTime && blockUpdatedTime > storyPublishedTime) {
+      
+      // TODO: Uncomment this when the storyPublishedTime is fixed
+      // if(storyPublishedTime && blockUpdatedTime > storyPublishedTime) {
 
       // Only upload media if the block has a file source
       if(block.fileSrc)
@@ -72,7 +74,7 @@ export class WhatsAppUploadMediaHandler extends FunctionHandler<CommunicationCha
           this._tools.Logger.log(()=> `Block ${block.id} updated with Media ID: ${mediaId}`);
         }
       }
-    }
+    // }
     }
 
     return {status: 200} as RestResult;

--- a/libs/model/convs-mgr/stories/blocks/messaging/src/lib/file-message-block.interface.ts
+++ b/libs/model/convs-mgr/stories/blocks/messaging/src/lib/file-message-block.interface.ts
@@ -12,6 +12,14 @@ export interface FileMessageBlock extends StoryBlock
   fileSrc?: string;
 
   defaultTarget?: string;
+
+  /**
+   * To improve performance, we upload the file to whatsapp first, then we get the url
+   *   as it takes time to do it in real time when sending the message
+   * 
+   * This is the url we get back after we upload the file to whatsapp 
+   */
+  whatsappMediaUrl?: string;
   
 }
 

--- a/libs/model/convs-mgr/stories/blocks/messaging/src/lib/file-message-block.interface.ts
+++ b/libs/model/convs-mgr/stories/blocks/messaging/src/lib/file-message-block.interface.ts
@@ -19,7 +19,7 @@ export interface FileMessageBlock extends StoryBlock
    * 
    * This is the url we get back after we upload the file to whatsapp 
    */
-  whatsappMediaUrl?: string;
+  whatsappMediaId?: string;
   
 }
 

--- a/libs/model/convs-mgr/stories/main/src/lib/story.interface.ts
+++ b/libs/model/convs-mgr/stories/main/src/lib/story.interface.ts
@@ -31,4 +31,7 @@ export interface Story extends IObject
 
   /* type of the story */
   isAssessment?: boolean
+
+  /* time of publishing */
+  publishedOn?: Date;
 }

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "firebase-functions": "^4.1.1",
     "firebase-tools": "^11.19.0",
     "lodash": "^4.17.21",
+    "mime-types": "^2.1.35",
     "moment": "^2.29.4",
     "ng-intercom": "^8.0.2",
     "ngx-google-places-autocomplete": "^2.0.5",
@@ -74,6 +75,7 @@
     "@types/crypto-js": "^4.1.1",
     "@types/jest": "27.4.1",
     "@types/lodash": "^4.14.182",
+    "@types/mime-types": "^2.1.1",
     "@types/node": "^16.11.7",
     "@typescript-eslint/eslint-plugin": "^5.29.0",
     "@typescript-eslint/parser": "^5.29.0",
@@ -102,6 +104,7 @@
     "lodash",
     "axios",
     "moment",
-    "crypto-js"
+    "crypto-js",
+    "mime-types"
   ]
 }


### PR DESCRIPTION
# Description

This solves the issue of medias lagging on whatsapp by coming after a text that was configured to follow it. Involves uploading the media to whatsapp using a handler and updating the media block with the returned whatsapp media id.

Created whatsapp media handler that:
- Goes through all the media blocks and uploads them to whatsap
- Updates the media blocks with the returned media id from whatsapp
- Whatsapp Outgoing Message Parser prioritizes using the media id if it is available


TODO:
- Enforce Whatsapp limit for Videos: 16MB, on the frontend
- The Uploaded media expires after 30 days. So a cron job is needed to update the media
- The handler can be triggered in publishing the story to whatsapp. Therefore when a story is published, we need a publishedOn field to be updated. So that the handler can compare the published date and the last time a block was updated to avoid redundancy
- Front end implementation needed
