### PR TITLE
🎨 Ability to copy block ID from the block itself #500

### DIFF
--- a/libs/features/convs-mgr/stories/blocks/library/jump-story-block/src/lib/components/jump-block/jump-block.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/jump-story-block/src/lib/components/jump-block/jump-block.component.html
@@ -4,7 +4,7 @@
       <option *ngFor="let story of stories" [value]='story.id'>{{story.name}}</option>
       <option [value]="null" [selected]="true">{{"PAGE-CONTENT.BLOCK.PLACEHOLDER.JUMP.SELECT-STORY" | transloco}}</option>
     </select>
-
+    <input type="text" formControlName="blockId" id="blockIdInput" placeholder="Paste Block ID here" />
     <input id="block" formControlName="targetBlockId" [placeholder]="'PAGE-CONTENT.BLOCK.PLACEHOLDER.JUMP.SELECT-BLOCK' | transloco" />
 
     <div formArrayName="options" fxFlexFill>

--- a/libs/features/convs-mgr/stories/blocks/library/jump-story-block/src/lib/components/jump-block/jump-block.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/jump-story-block/src/lib/components/jump-block/jump-block.component.html
@@ -4,7 +4,7 @@
       <option *ngFor="let story of stories" [value]='story.id'>{{story.name}}</option>
       <option [value]="null" [selected]="true">{{"PAGE-CONTENT.BLOCK.PLACEHOLDER.JUMP.SELECT-STORY" | transloco}}</option>
     </select>
-    <input type="text" formControlName="blockId" id="blockIdInput" placeholder="Paste Block ID here" />
+    
     <input id="block" formControlName="targetBlockId" [placeholder]="'PAGE-CONTENT.BLOCK.PLACEHOLDER.JUMP.SELECT-BLOCK' | transloco" />
 
     <div formArrayName="options" fxFlexFill>

--- a/libs/features/convs-mgr/stories/blocks/library/jump-story-block/src/lib/components/jump-block/jump-block.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/jump-story-block/src/lib/components/jump-block/jump-block.component.ts
@@ -1,5 +1,6 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormArray, FormBuilder, FormGroup } from '@angular/forms';
+import { Clipboard } from '@angular/cdk/clipboard';
 
 import { SubSink } from 'subsink';
 
@@ -49,7 +50,9 @@ export class JumpBlockComponent implements OnInit, OnDestroy
     private _fb: FormBuilder,
     private _storyBlockStore$$: StoryBlocksStore,
     private _translate: TranslateService,
-    private _logger: Logger)
+    private _logger: Logger,
+    private clipboard: Clipboard,
+    )
   { }
 
   ngOnInit(): void
@@ -58,6 +61,9 @@ export class JumpBlockComponent implements OnInit, OnDestroy
 
     this.getStories();
     this.getBlocks();
+
+    const inputElement = document.getElementById('blockIdInput') as HTMLInputElement;
+    inputElement.addEventListener('paste', (event) => this.handlePaste(event));
   }
 
   get options(): FormArray
@@ -111,6 +117,14 @@ export class JumpBlockComponent implements OnInit, OnDestroy
       {
         this.blocks = blocks;
       });
+  }
+
+  handlePaste(event: ClipboardEvent){
+    const clipboardData = event.clipboardData || (window as any).clipboardData;
+    const pasteID = clipboardData.getData('text/plain')
+    const blockId = pasteID.trim()
+    this.jumpBlockForm.patchValue({ blockId: blockId})
+    event.preventDefault();
   }
 
   ngOnDestroy()

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.html
@@ -1,4 +1,4 @@
-<mat-card  class="card" [id]="id" class="block-card" (contextmenu)="copyBlockIdToClipboard($event)">
+<mat-card  class="card" [id]="id" class="block-card" (contextmenu)="copyBlockIdToClipboard($event)" (click)="hideCopyBtn()">
     <div [ngSwitch]="type">
         <div *ngIf="type !== endStoryAnchor" class="outer">
             <div class="block-title-container">
@@ -10,8 +10,11 @@
                 <span (click)="editBlock()" class="icons"><i class="far fa-edit"></i></span>
                 <span (click)="copyblock(block)" class="icons"><i class="far fa-clone"></i></span>
                 <span (click)="deleteBlock()" class="icons"><i class="far fa-trash-alt"></i></span>
-                <span (click)="copyBlockIdToClipboard($event)" class="icons"><i class="far fa-clipboard"></i></span>
+                <div class="copy-button-container " *ngIf="showCopyBtn">
+                    <span (click)="copyBlockIdToClipboard($event)" class="icons" id="copy-span"><i class="far fa-clone"></i>Copy Reference</span> 
+                </div>
             </div>
+            
         </div>
 
         <div *ngSwitchCase="messagetype">

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.html
@@ -6,10 +6,10 @@
                 <h4 class="block-title"> {{ blockTitle | transloco }}</h4>
             </div>
 
-            <div fxLayout="row" class="icon-block">
-                <span (click)="editBlock()" class="icons"><i class="far fa-edit"></i></span>
-                <span (click)="copyblock(block)" class="icons"><i class="far fa-clone"></i></span>
-                <span (click)="deleteBlock()" class="icons"><i class="far fa-trash-alt"></i></span>
+            <div fxLayout="row" class="icon-block"> 
+                <span *ngIf="!showCopyBtn" (click)="editBlock()" class="icons"><i class="far fa-edit"></i></span>
+                <span *ngIf="!showCopyBtn" (click)="copyblock(block)" class="icons"><i class="far fa-clone"></i></span>
+                <span *ngIf="!showCopyBtn" (click)="deleteBlock()" class="icons"><i class="far fa-trash-alt"></i></span>
                 <div class="copy-button-container " *ngIf="showCopyBtn">
                     <span (click)="copyBlockIdToClipboard($event)" class="icons" id="copy-span"><i class="far fa-clone"></i>Copy Reference</span> 
                 </div>

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.html
@@ -1,4 +1,4 @@
-<mat-card  class="card" [id]="id" class="block-card">
+<mat-card  class="card" [id]="id" class="block-card" (contextmenu)="copyBlockIdToClipboard($event)">
     <div [ngSwitch]="type">
         <div *ngIf="type !== endStoryAnchor" class="outer">
             <div class="block-title-container">
@@ -10,6 +10,7 @@
                 <span (click)="editBlock()" class="icons"><i class="far fa-edit"></i></span>
                 <span (click)="copyblock(block)" class="icons"><i class="far fa-clone"></i></span>
                 <span (click)="deleteBlock()" class="icons"><i class="far fa-trash-alt"></i></span>
+                <span (click)="copyBlockIdToClipboard($event)" class="icons"><i class="far fa-clipboard"></i></span>
             </div>
         </div>
 

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.scss
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.scss
@@ -72,14 +72,19 @@ mat-card {
 ::ng-deep .mat-mdc-card-content {
 	padding: 0;
 }
-.copy-button-container{
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  margin-right: auto;
-  #copy-span{
-	width: 150px;
-	background-color: var(--convs-mgr-color-light-shade);
-	color: var(--convs-mgr-color-medium-shade);
-}
-}
+
+.copy-button-container {
+	display: flex;
+	align-items: center;
+	gap: 10px;
+	margin-left: auto; 
+
+	#copy-span {
+		background-color: var(--convs-mgr-color-light-shade);
+		color: var(--convs-mgr-color-medium-shade);
+		padding: 5px 10px; 
+		border-radius: 4px; 
+		cursor: pointer;
+	  }
+  }
+  

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.scss
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.scss
@@ -63,6 +63,7 @@ mat-card {
 			}
 		}
 	}
+	
 }
 .hide-block {
 	display: none;
@@ -70,4 +71,15 @@ mat-card {
 
 ::ng-deep .mat-mdc-card-content {
 	padding: 0;
+}
+.copy-button-container{
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-right: auto;
+  #copy-span{
+	width: 150px;
+	background-color: var(--convs-mgr-color-light-shade);
+	color: var(--convs-mgr-color-medium-shade);
+}
 }

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.ts
@@ -7,6 +7,7 @@ import { MatDialog } from '@angular/material/dialog';
 import { BrowserJsPlumbInstance } from '@jsplumb/browser-ui';
 
 import { Logger } from '@iote/bricks-angular';
+import { Clipboard } from '@angular/cdk/clipboard';
 
 import { BlockPortalService } from '@app/features/convs-mgr/stories/editor';
 import { StoryBlock, StoryBlockTypes } from '@app/model/convs-mgr/stories/blocks/main';
@@ -116,7 +117,8 @@ export class BlockComponent implements OnInit {
               private _logger: Logger,
               private sideMenu:SidemenuToggleService,
               private sideScreen:SideScreenToggleService,
-              private matdialog: MatDialog
+              private matdialog: MatDialog,
+              private clipboard: Clipboard
 
   ) { }
 
@@ -348,5 +350,16 @@ export class BlockComponent implements OnInit {
     this.viewPort.remove(index);
     this._cd.detectChanges();
   }
+
+  copyBlockIdToClipboard(event: MouseEvent) {
+    event.preventDefault(); // Prevent the default context menu from showing up
+    const blockId = this.id;
+    navigator.clipboard.writeText(blockId).then(
+      () => console.log('Block ID copied to clipboard: ', blockId),
+      (error) => console.error('Failed to copy block ID: ', error)
+    );
+  }
+  
+  
 }
 

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.ts
@@ -360,6 +360,17 @@ export class BlockComponent implements OnInit {
     );
   }
   
+  showCopyBtn = false;
+
+  @HostListener('contextmenu', ['$event'])
+  onContextMenu(event: MouseEvent) {
+    event.preventDefault(); // Prevent the default context menu from showing up
+    this.showCopyBtn = true;
+  }
+
+  hideCopyBtn() {
+    this.showCopyBtn = false;
+  }
   
 }
 

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.ts
@@ -354,10 +354,7 @@ export class BlockComponent implements OnInit {
   copyBlockIdToClipboard(event: MouseEvent) {
     event.preventDefault(); // Prevent the default context menu from showing up
     const blockId = this.id;
-    navigator.clipboard.writeText(blockId).then(
-      () => console.log('Block ID copied to clipboard: ', blockId),
-      (error) => console.error('Failed to copy block ID: ', error)
-    );
+    navigator.clipboard.writeText(blockId)
   }
   
   showCopyBtn = false;


### PR DESCRIPTION
# Description

When I right click on the top of a block, a button should appear allowing me to copy the block ID.
When I click this button, the block ID should be copied to my clipboard.
When I go to the jump block, I should be able to paste the previously copied ID into the jump block.

Fixes #500
## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)


# Screenshot (optional)
[Screencast from 27-07-23 14:13:48.webm](https://github.com/italanta/elewa/assets/109944021/984a4db0-0a6c-4c55-809f-b84bd656b3ac)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
