### PR TITLE
:sparkles: CLM-135:  Blocks and connections keep refreshing on the story editor

### DIFF
--- a/libs/features/convs-mgr/stories/editor/src/index.ts
+++ b/libs/features/convs-mgr/stories/editor/src/index.ts
@@ -1,3 +1,4 @@
 export * from './lib/convl-story-editor.module';
 export * from './lib/providers/block-portal.service';
 export * from './lib/providers/side-screen-toggle.service'
+export * from './lib/providers/editor-frame-spinner.service'

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/editor-frame/editor-frame.component.html
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/editor-frame/editor-frame.component.html
@@ -9,17 +9,22 @@
   (pinch$)="onPinch($event)"
   
 >
-  <div 
-  infinite-scroll 
-  [scrollWindow]="true" 
-  [horizontal]="true" 
-  [infiniteScrollContainer]="editorVC" 
-  [fromRoot]="false" 
-  convlTrackCursor
-  [infiniteScrollDistance]="9"
-    [infiniteScrollThrottle]="150" 
-    (scrolled)="onScroll()"
-     #editor id="editor-frame" style="position: relative" fxFlex="95">
-    <ng-template id="viewport" #viewport></ng-template>
+<div class="editor-container">
+  <div class="spinner" *ngIf="showEditorSpinner">
+   <mat-spinner></mat-spinner>
   </div>
+   <div 
+   infinite-scroll 
+   [scrollWindow]="true" 
+   [horizontal]="true" 
+   [infiniteScrollContainer]="editorVC" 
+   [fromRoot]="false" 
+   convlTrackCursor
+   [infiniteScrollDistance]="9"
+     [infiniteScrollThrottle]="150" 
+     (scrolled)="onScroll()"
+      #editor id="editor-frame" style="position: relative" fxFlex="95">
+     <ng-template id="viewport" #viewport></ng-template>
+   </div>
+</div>
 </div>

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/editor-frame/editor-frame.component.scss
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/editor-frame/editor-frame.component.scss
@@ -1,9 +1,23 @@
-// #editor-frame {
-//   min-height: 20000px!important;
-//   min-width: 20000px!important;
-//   // overflow-x: scroll!important;
-//   // overflow-x: scroll!important;
-// }
+#editor-frame {
+  min-height: 20000px!important;
+  min-width: 20000px!important;
+  overflow-x: scroll!important;
+  overflow-x: scroll!important;
+}
+.spinner{
+  background-color: white;
+  min-height: 20000px!important;
+  min-width: 20000px!important;
+  position: sticky!important;
+  bottom: 0;
+  right: 0;
+  z-index: 2000;
+}
+mat-spinner {
+  position: sticky!important;
+  top: 30%;
+  left: 30%;
+}
 
 #editor-frame .block {
   position: absolute;
@@ -30,5 +44,8 @@ app-message-block {
   background-repeat: no-repeat;
   overflow: scroll;
   position: fixed;
-  //border: 9px solid red;
 }
+// .editor-container{
+//   min-width: 100vw;
+//   min-height: 100vh;
+// }

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/editor-frame/editor-frame.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/editor-frame/editor-frame.component.ts
@@ -2,6 +2,8 @@ import { AfterViewInit, Component, ElementRef, Output, EventEmitter, ViewChild, 
 import { StoryEditorFrame } from '../../model/story-editor-frame.model';  
 
 import { StoryEditorInitialiserService } from '../../providers/story-editor-initialiser.service';
+import { SubSink } from 'subsink';
+import { EditorFrameLoadingService } from '../../providers/editor-frame-spinner.service';
 
 @Component({
   selector: 'convl-story-editor-frame',
@@ -15,11 +17,17 @@ export class StoryEditorFrameComponent implements AfterViewInit //implements OnD
 
   @Output() frameLoaded = new EventEmitter<StoryEditorFrame>;
   @Output()pinchZoom = new EventEmitter<number>()
+  private _sb = new SubSink();
+  showEditorSpinner: boolean
 
-  constructor(private _frameInitialiser: StoryEditorInitialiserService) { }
+  constructor(private _frameInitialiser: StoryEditorInitialiserService, private _editorLoading: EditorFrameLoadingService) { }
 
 
   ngAfterViewInit() {
+    this._sb.sink = this._editorLoading.loaded$.subscribe((loading) => {
+      this.showEditorSpinner = loading;
+      console.log("The state is "+ loading)
+    });
     const frame = this._frameInitialiser.initialiseEditor(this.editorVC, this.viewport);
 
     this.frameLoaded.emit(frame);

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/editor-frame/editor-frame.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/editor-frame/editor-frame.component.ts
@@ -26,7 +26,6 @@ export class StoryEditorFrameComponent implements AfterViewInit //implements OnD
   ngAfterViewInit() {
     this._sb.sink = this._editorLoading.loaded$.subscribe((loading) => {
       this.showEditorSpinner = loading;
-      console.log("The state is "+ loading)
     });
     const frame = this._frameInitialiser.initialiseEditor(this.editorVC, this.viewport);
 

--- a/libs/features/convs-mgr/stories/editor/src/lib/components/editor-frame/editor-frame.component.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/components/editor-frame/editor-frame.component.ts
@@ -1,8 +1,9 @@
 import { AfterViewInit, Component, ElementRef, Output, EventEmitter, ViewChild, ViewContainerRef } from '@angular/core';
-import { StoryEditorFrame } from '../../model/story-editor-frame.model';  
 
-import { StoryEditorInitialiserService } from '../../providers/story-editor-initialiser.service';
 import { SubSink } from 'subsink';
+
+import { StoryEditorFrame } from '../../model/story-editor-frame.model';  
+import { StoryEditorInitialiserService } from '../../providers/story-editor-initialiser.service';
 import { EditorFrameLoadingService } from '../../providers/editor-frame-spinner.service';
 
 @Component({

--- a/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
@@ -16,6 +16,7 @@ import { BlockConnectionsService } from '@app/state/convs-mgr/stories/block-conn
 import { Coordinate } from './coordinates.interface';
 import { EndStoryAnchorBlock } from '@app/model/convs-mgr/stories/blocks/messaging';
 import { EditorFrameLoadingService } from '../providers/editor-frame-spinner.service';
+import { Logger } from '@iote/bricks-angular';
 
 /**
  * Model which holds the state of a story-editor.
@@ -41,7 +42,8 @@ export class StoryEditorFrame {
     private _viewport: ViewContainerRef,
     private _connectionsService: BlockConnectionsService,
     private _edf: ElementRef<HTMLElement>,
-    private _frameLoading: EditorFrameLoadingService
+    private _frameLoading: EditorFrameLoadingService,
+    private _logger: Logger
   ) {
     this.loaded = true;
   }
@@ -55,7 +57,7 @@ export class StoryEditorFrame {
    */
   async init(state: StoryEditorState) {
 
-    console.log('show pinner')
+    this._logger.log(()=>'show spinner')
     this._frameLoading.changeLoadingState(true)
 
     this._state = state;
@@ -77,7 +79,7 @@ export class StoryEditorFrame {
     await new Promise((resolve) => setTimeout(() => resolve(true), 1000)); // gives some time for drawing to end
 
     this.drawConnections();
-    console.log('frame initialised')
+    this._logger.log(() => 'frame initialised')
     this._frameLoading.changeLoadingState(false);
 
     //scroll to the middle of the screen when connections are done drawing

--- a/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
@@ -11,12 +11,12 @@ import { StoryEditorState } from '@app/state/convs-mgr/story-editor';
 
 import { BlockInjectorService } from '@app/features/convs-mgr/stories/blocks/library/main';
 import { AnchorBlockComponent } from '@app/features/convs-mgr/stories/blocks/library/anchor-block';
+import { BlockConnectionsService } from '@app/state/convs-mgr/stories/block-connections';
+import { EndStoryAnchorBlock } from '@app/model/convs-mgr/stories/blocks/messaging';
 
 import { CreateDeleteButton, DeleteConnectorbyID } from '../providers/manage-jsPlumb-connections.function';
-import { BlockConnectionsService } from '@app/state/convs-mgr/stories/block-connections';
-import { Coordinate } from './coordinates.interface';
-import { EndStoryAnchorBlock } from '@app/model/convs-mgr/stories/blocks/messaging';
 import { EditorFrameLoadingService } from '../providers/editor-frame-spinner.service';
+import { Coordinate } from './coordinates.interface';
 
 /**
  * Model which holds the state of a story-editor.

--- a/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
@@ -1,6 +1,7 @@
 import { ElementRef, ViewContainerRef } from '@angular/core';
 import { FormArray, FormBuilder } from '@angular/forms';
 
+import { Logger } from '@iote/bricks-angular';
 import { BrowserJsPlumbInstance } from '@jsplumb/browser-ui';
 
 import { Story } from '@app/model/convs-mgr/stories/main';
@@ -16,7 +17,6 @@ import { BlockConnectionsService } from '@app/state/convs-mgr/stories/block-conn
 import { Coordinate } from './coordinates.interface';
 import { EndStoryAnchorBlock } from '@app/model/convs-mgr/stories/blocks/messaging';
 import { EditorFrameLoadingService } from '../providers/editor-frame-spinner.service';
-import { Logger } from '@iote/bricks-angular';
 
 /**
  * Model which holds the state of a story-editor.

--- a/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
@@ -15,6 +15,7 @@ import { CreateDeleteButton, DeleteConnectorbyID } from '../providers/manage-jsP
 import { BlockConnectionsService } from '@app/state/convs-mgr/stories/block-connections';
 import { Coordinate } from './coordinates.interface';
 import { EndStoryAnchorBlock } from '@app/model/convs-mgr/stories/blocks/messaging';
+import { EditorFrameLoadingService } from '../providers/editor-frame-spinner.service';
 
 /**
  * Model which holds the state of a story-editor.
@@ -39,7 +40,8 @@ export class StoryEditorFrame {
     private _blocksInjector: BlockInjectorService,
     private _viewport: ViewContainerRef,
     private _connectionsService: BlockConnectionsService,
-    private _edf: ElementRef<HTMLElement>
+    private _edf: ElementRef<HTMLElement>,
+    private _frameLoading: EditorFrameLoadingService
   ) {
     this.loaded = true;
   }
@@ -52,6 +54,10 @@ export class StoryEditorFrame {
    * @param blocks  - Blocks to render on the story
    */
   async init(state: StoryEditorState) {
+
+    console.log('show pinner')
+    this._frameLoading.changeLoadingState(true)
+
     this._state = state;
     this._story = state.story;
     this._blocks = state.blocks;
@@ -71,6 +77,8 @@ export class StoryEditorFrame {
     await new Promise((resolve) => setTimeout(() => resolve(true), 1000)); // gives some time for drawing to end
 
     this.drawConnections();
+    console.log('frame initialised')
+    this._frameLoading.changeLoadingState(false);
 
     //scroll to the middle of the screen when connections are done drawing
     this.scroll(this._edf.nativeElement)
@@ -78,8 +86,12 @@ export class StoryEditorFrame {
   scroll(el: HTMLElement) {
     const editorWidth = this._edf.nativeElement.offsetWidth / 2;
     const editorHeight = this._edf.nativeElement.offsetHeight / 2;
-    el.scrollTo({top:editorHeight,left:editorWidth});
+
+    // el.scrollTo({top:editorHeight,left:editorWidth});
     // el.scrollIntoView({block: 'center', inline: 'center',behavior: 'smooth'});
+    el.style.top = editorHeight.toString()
+    el.style.left = editorWidth.toString()
+    el.style.transform = "translate(-50%, -50%)"
   }
 
   get jsPlumbInstance(): BrowserJsPlumbInstance {

--- a/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
@@ -43,7 +43,6 @@ export class StoryEditorFrame {
     private _connectionsService: BlockConnectionsService,
     private _edf: ElementRef<HTMLElement>,
     private _frameLoading: EditorFrameLoadingService,
-    private _logger: Logger
   ) {
     this.loaded = true;
   }
@@ -57,7 +56,9 @@ export class StoryEditorFrame {
    */
   async init(state: StoryEditorState) {
 
-    this._logger.log(()=>'show spinner')
+    const logger = new Logger()
+    logger.log(() => 'The frame is being initialised')
+
     this._frameLoading.changeLoadingState(true)
 
     this._state = state;
@@ -79,7 +80,7 @@ export class StoryEditorFrame {
     await new Promise((resolve) => setTimeout(() => resolve(true), 1000)); // gives some time for drawing to end
 
     this.drawConnections();
-    this._logger.log(() => 'frame initialised')
+    
     this._frameLoading.changeLoadingState(false);
 
     //scroll to the middle of the screen when connections are done drawing

--- a/libs/features/convs-mgr/stories/editor/src/lib/pages/story-editor/story-editor.page.html
+++ b/libs/features/convs-mgr/stories/editor/src/lib/pages/story-editor/story-editor.page.html
@@ -31,10 +31,7 @@
       </div>
 
       <!-- Convl page subbar -->
-      <ng-container *ngIf="!stateSaved; else Loading"
-      >LOadingg ..
-    </ng-container>
-      <ng-template #Loading>
+
         <div class="sub-bar" subbar fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="space-between center">
           <div fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="start center">
             <button class="zoom-btn" [disabled]="zoomLevel.value <= 25" mat-mini-fab (click)="decreaseFrameZoom()">
@@ -67,7 +64,6 @@
         </div>
         <convl-story-editor-frame (frameLoaded)="onFrameViewLoaded($event)" fxFlex="100" (pinchZoom)="setZoomByPinch($event)">
         </convl-story-editor-frame>
-      </ng-template>
       
 
 

--- a/libs/features/convs-mgr/stories/editor/src/lib/pages/story-editor/story-editor.page.html
+++ b/libs/features/convs-mgr/stories/editor/src/lib/pages/story-editor/story-editor.page.html
@@ -31,39 +31,49 @@
       </div>
 
       <!-- Convl page subbar -->
-      <div class="sub-bar" subbar fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="space-between center">
-        <div fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="start center">
-          <button class="zoom-btn" [disabled]="zoomLevel.value <= 25" mat-mini-fab (click)="decreaseFrameZoom()">
-            <mat-icon>zoom_out</mat-icon>
-          </button>
-
-          <input style="margin-right: 0px;" [formControl]="zoomLevel" min="25" max="100" (change)="zoomChanged($event)"
-            type="number">
-
-          <button class="zoom-btn" [disabled]="zoomLevel.value >= 100" mat-mini-fab (click)="increaseFrameZoom()">
-            <mat-icon>zoom_in</mat-icon>
-          </button>
+      <ng-container *ngIf="!stateSaved; else Loading"
+      >LOadingg ..
+    </ng-container>
+      <ng-template #Loading>
+        <div class="sub-bar" subbar fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="space-between center">
+          <div fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="start center">
+            <button class="zoom-btn" [disabled]="zoomLevel.value <= 25" mat-mini-fab (click)="decreaseFrameZoom()">
+              <mat-icon>zoom_out</mat-icon>
+            </button>
+  
+            <input style="margin-right: 0px;" [formControl]="zoomLevel" min="25" max="100" (change)="zoomChanged($event)"
+              type="number">
+  
+            <button class="zoom-btn" [disabled]="zoomLevel.value >= 100" mat-mini-fab (click)="increaseFrameZoom()">
+              <mat-icon>zoom_in</mat-icon>
+            </button>
+          </div>
+  
+          <div fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="start center">
+            <button [disabled]="hasEmptyFields || !stateSaved" (click)="save()" mat-flat-button class="subbar-btn">
+              <span *ngIf="stateSaved; else saving"> Save </span>
+              <ng-template #saving>
+                <span fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="10px">
+                  <span> {{'PAGE-CONTENT.TOP-BAR.SAVE-STORY' | transloco }} </span>
+                  <mat-spinner diameter="20"></mat-spinner>
+                </span>
+              </ng-template>
+            </button>
+  
+            <button [disabled]="!storyHasBeenSaved" (click)="addToChannel()" mat-flat-button class="add-channel-btn">
+              <span> {{'PAGE-CONTENT.TOP-BAR.PUBLISH-STORY' | transloco }} </span>
+            </button>
+          </div>
         </div>
+        <convl-story-editor-frame (frameLoaded)="onFrameViewLoaded($event)" fxFlex="100" (pinchZoom)="setZoomByPinch($event)">
+        </convl-story-editor-frame>
+      </ng-template>
+      
 
-        <div fxLayout="row" fxLayoutGap="10px" fxLayoutAlign="start center">
-          <button [disabled]="hasEmptyFields || !stateSaved" (click)="save()" mat-flat-button class="subbar-btn">
-            <span *ngIf="stateSaved; else saving"> Save </span>
-            <ng-template #saving>
-              <span fxLayout="row" fxLayoutAlign="start center" fxLayoutGap="10px">
-                <span> {{'PAGE-CONTENT.TOP-BAR.SAVE-STORY' | transloco }} </span>
-                <mat-spinner diameter="20"></mat-spinner>
-              </span>
-            </ng-template>
-          </button>
 
-          <button [disabled]="!storyHasBeenSaved" (click)="addToChannel()" mat-flat-button class="add-channel-btn">
-            <span> {{'PAGE-CONTENT.TOP-BAR.PUBLISH-STORY' | transloco }} </span>
-          </button>
-        </div>
-      </div>
-      <convl-story-editor-frame (frameLoaded)="onFrameViewLoaded($event)" fxFlex="100" (pinchZoom)="setZoomByPinch($event)">
-      </convl-story-editor-frame>
+
     </div>
+
 
   </div>
 </convl-page>

--- a/libs/features/convs-mgr/stories/editor/src/lib/pages/story-editor/story-editor.page.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/pages/story-editor/story-editor.page.ts
@@ -89,7 +89,6 @@ export class StoryEditorPageComponent implements OnInit, OnDestroy {
     ngOnInit() {
       this._sb.sink = this.sideScreen.sideScreen$.subscribe((isOpen) => {
         this.isSideScreenOpen = isOpen
-        console.log("The sidescren status is "+ isOpen)
       });
 
       this._sb.sink = this._blockPortalService.portal$.subscribe((blockDetails) => {

--- a/libs/features/convs-mgr/stories/editor/src/lib/pages/story-editor/story-editor.page.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/pages/story-editor/story-editor.page.ts
@@ -23,6 +23,7 @@ import { getActiveBlock } from '../../providers/fetch-active-block-component.fun
 import { ErrorPromptModalComponent } from '@app/elements/layout/modals';
 import { SideScreenToggleService } from '../../providers/side-screen-toggle.service';
 import { EditorFrameLoadingService } from '../../providers/editor-frame-spinner.service';
+
 @Component({
   selector: 'convl-story-editor-page',
   templateUrl: './story-editor.page.html',

--- a/libs/features/convs-mgr/stories/editor/src/lib/pages/story-editor/story-editor.page.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/pages/story-editor/story-editor.page.ts
@@ -14,13 +14,13 @@ import { Breadcrumb, Logger } from '@iote/bricks-angular';
 import { StoryEditorState, StoryEditorStateService } from '@app/state/convs-mgr/story-editor';
 
 import { HOME_CRUMB, STORY_EDITOR_CRUMB } from '@app/elements/nav/convl/breadcrumbs';
+import { ErrorPromptModalComponent } from '@app/elements/layout/modals';
 
 import { BlockPortalService } from '../../providers/block-portal.service';
 import { StoryEditorFrame } from '../../model/story-editor-frame.model';
 import { AddBotToChannelModal } from '../../modals/add-bot-to-channel-modal/add-bot-to-channel.modal';
 
 import { getActiveBlock } from '../../providers/fetch-active-block-component.function';
-import { ErrorPromptModalComponent } from '@app/elements/layout/modals';
 import { SideScreenToggleService } from '../../providers/side-screen-toggle.service';
 import { EditorFrameLoadingService } from '../../providers/editor-frame-spinner.service';
 

--- a/libs/features/convs-mgr/stories/editor/src/lib/providers/editor-frame-spinner.service.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/providers/editor-frame-spinner.service.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@angular/core';
+
 import { BehaviorSubject } from 'rxjs';
 
 @Injectable({

--- a/libs/features/convs-mgr/stories/editor/src/lib/providers/editor-frame-spinner.service.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/providers/editor-frame-spinner.service.ts
@@ -1,0 +1,14 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class EditorFrameLoadingService {
+  private _loading = new BehaviorSubject(true);
+  loaded$ = this._loading.asObservable();
+
+  changeLoadingState(value: boolean) {
+    this._loading.next(value);
+  }
+}

--- a/libs/features/convs-mgr/stories/editor/src/lib/providers/story-editor-initialiser.service.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/providers/story-editor-initialiser.service.ts
@@ -8,12 +8,14 @@ import { BlockInjectorService } from '@app/features/convs-mgr/stories/blocks/lib
 import { BlockConnectionsService } from '@app/state/convs-mgr/stories/block-connections';
 
 import { StoryEditorFrame } from '../model/story-editor-frame.model';
+import { EditorFrameLoadingService } from './editor-frame-spinner.service';
 
 @Injectable()
 export class StoryEditorInitialiserService {
   constructor(private _fb: FormBuilder,
     private _blocksInjector: BlockInjectorService,
-    private _connectionsService: BlockConnectionsService
+    private _connectionsService: BlockConnectionsService,
+    private _showEditorSpinner: EditorFrameLoadingService
   ) { }
 
   initialiseEditor(editorContainer: ElementRef<HTMLElement>,
@@ -31,6 +33,6 @@ export class StoryEditorInitialiserService {
 
     _jsplumb.addClass(container, "jsplumb_instance")
 
-    return new StoryEditorFrame(this._fb, _jsplumb, this._blocksInjector, viewport, this._connectionsService, editorContainer);
+    return new StoryEditorFrame(this._fb, _jsplumb, this._blocksInjector, viewport, this._connectionsService, editorContainer, this._showEditorSpinner);
   }
 }

--- a/libs/state/convs-mgr/story-editor/src/lib/providers/story-editor-state.service.ts
+++ b/libs/state/convs-mgr/story-editor/src/lib/providers/story-editor-state.service.ts
@@ -13,10 +13,10 @@ import { StoryBlock, StoryBlockConnection } from '@app/model/convs-mgr/stories/b
 import { ActiveStoryStore } from '@app/state/convs-mgr/stories';
 import { StoryBlocksStore } from '@app/state/convs-mgr/stories/blocks';
 import { BlockConnectionsService, StoryConnectionsStore } from '@app/state/convs-mgr/stories/block-connections';
+import { EditorFrameLoadingService } from '@app/features/convs-mgr/stories/editor';
+
 
 import { StoryEditorState } from '../model/story-editor-state.model';
-import { EditorFrameLoadingService } from 'libs/features/convs-mgr/stories/editor/src/lib/providers/editor-frame-spinner.service';
-
 /** 
  * Service responsible for persisting the state of stories from the editor.
  *

--- a/libs/state/convs-mgr/story-editor/src/lib/providers/story-editor-state.service.ts
+++ b/libs/state/convs-mgr/story-editor/src/lib/providers/story-editor-state.service.ts
@@ -15,6 +15,7 @@ import { StoryBlocksStore } from '@app/state/convs-mgr/stories/blocks';
 import { BlockConnectionsService, StoryConnectionsStore } from '@app/state/convs-mgr/stories/block-connections';
 
 import { StoryEditorState } from '../model/story-editor-state.model';
+import { EditorFrameLoadingService } from 'libs/features/convs-mgr/stories/editor/src/lib/providers/editor-frame-spinner.service';
 
 /** 
  * Service responsible for persisting the state of stories from the editor.
@@ -37,7 +38,8 @@ export class StoryEditorStateService {
     private _connections$$: StoryConnectionsStore,
     private _blockConnectionsService: BlockConnectionsService,
     private _aFF: AngularFireFunctions,
-    private _logger: Logger
+    private _logger: Logger,
+    private _showEditorSpinner: EditorFrameLoadingService
   ) {}
 
   /**
@@ -131,6 +133,7 @@ export class StoryEditorStateService {
       }),
       catchError((err) => {
         this._logger.log(() => `Error saving story editor state, ${err}`);
+        this._showEditorSpinner.changeLoadingState(false);
         alert(
           'Error saving story, please try again. If the problem persists, contact support.'
         );


### PR DESCRIPTION
# Description
Added a spinner  to the editor page to hide the flickering of blocks while being drawn.

fixes Clm 135 blocks and connections keep refreshing on the story editor



## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update


# Checklist:

- [X ] My code follows the style guidelines of this project
- [ X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
