### PR TITLE
🔧 CLM-46 Order The Chats Data Starting From The Latest Chat

### DIFF
--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chats-list/chats-list.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chats-list/chats-list.component.ts
@@ -75,7 +75,9 @@ export class ChatsListComponent implements AfterViewInit, OnInit
 
     this._sbs.sink = this._activeChat$.get().pipe(filter(x => !!x)).subscribe((chat) => this.currentChat = chat);
 
-    this.chats$ = this._chats$.get();
+    // this.chats$ = this._chats$.get();
+    // this._sbs.sink = this.chats$.subscribe(chatList => this.getChats(chatList));
+    this.chats$  = this._msgsQuery$.getChats();
     this._sbs.sink = this.chats$.subscribe(chatList => this.getChats(chatList));
   }
 
@@ -96,39 +98,16 @@ export class ChatsListComponent implements AfterViewInit, OnInit
     });
   }
 
-  getChats(chatList: Chat[]) {
+  getChats(chatList: Chat[])
+  {
     this.dataSource = new MatTableDataSource<any>();
     this.chats$ = this.dataSource.connect();
-    const lastMessageTimestamps: Date[] = []; // Use Date objects instead of numbers
-  
-    chatList.forEach(chat => {
-      this.newDate.push(chat.createdOn);
-      this._msgsQuery$.getLatestMessageDate(chat.id).subscribe(date => {
-        chat.lastMsg = date; // Assign the latest message date to the chat object
-  
-        // Combine seconds and nanoseconds into milliseconds
-        const timestampMilliseconds = date.seconds * 1000 + date.nanoseconds / 1e6;
-        
-        // Create a Date object using the combined timestamp
-        const dateObject = new Date(timestampMilliseconds);
-        
-        lastMessageTimestamps.push(dateObject); // Store the Date object in the array
-        this.applySorting(chatList, lastMessageTimestamps);
-      });
-    });
-  }
-  
-  applySorting(chatList: Chat[], lastMessageTimestamps: Date[]) {
-    // Sort chatList based on lastMessageTimestamps
-    chatList.sort((a, b) => {
-      const timestampA = lastMessageTimestamps[chatList.indexOf(a)];
-      const timestampB = lastMessageTimestamps[chatList.indexOf(b)];
-      return timestampB.getTime() - timestampA.getTime();// Compare timestamps and return the comparison result.
-    });
-  
+
     this.chats = chatList;
     this.initializeLists();
-  
+    //Set into categories
+    chatList.forEach(chat => this.categorize(chat));
+
     if (!this.filtrString) this.filtrString = '';
     this.applyFilter();
     this.dataSource.paginator = this.paginator?.first;

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chats-list/chats-list.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chats-list/chats-list.component.ts
@@ -75,7 +75,7 @@ export class ChatsListComponent implements AfterViewInit, OnInit
 
     this._sbs.sink = this._activeChat$.get().pipe(filter(x => !!x)).subscribe((chat) => this.currentChat = chat);
 
-    this.chats$  = this._chatStore$.getChatsWithLatestMessageDate();
+    this.chats$  = this._chatStore$.getOrderedChats();
     this._sbs.sink = this.chats$.subscribe(chatList => this.getChats(chatList));
   }
 

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chats-list/chats-list.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chats-list/chats-list.component.ts
@@ -75,8 +75,6 @@ export class ChatsListComponent implements AfterViewInit, OnInit
 
     this._sbs.sink = this._activeChat$.get().pipe(filter(x => !!x)).subscribe((chat) => this.currentChat = chat);
 
-    // this.chats$ = this._chats$.get();
-    // this._sbs.sink = this.chats$.subscribe(chatList => this.getChats(chatList));
     this.chats$  = this._msgsQuery$.getChats();
     this._sbs.sink = this.chats$.subscribe(chatList => this.getChats(chatList));
   }
@@ -93,7 +91,6 @@ export class ChatsListComponent implements AfterViewInit, OnInit
     {
       if (this.paginator.length && this.dataSource) {
         this.dataSource.paginator = this.paginator?.first;
-        // this.cd.detectChanges();
       }
     });
   }

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chats-list/chats-list.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chats-list/chats-list.component.ts
@@ -54,7 +54,7 @@ export class ChatsListComponent implements AfterViewInit, OnInit
   stashed: Chat[];
   blocked: Chat[];
 
-  newDate : any[] = [];
+  newDate : Date[] = [];
   
   @ViewChildren(MatPaginator) paginator: QueryList<MatPaginator>;
 

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chats-list/chats-list.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chats-list/chats-list.component.ts
@@ -19,7 +19,7 @@ import { Chat, ChatFlowStatus } from '@app/model/convs-mgr/conversations/chats';
 import { Payment, PaymentStatus } from '@app/model/finance/payments';
 
 import { ChatsStore, ActiveChatConnectedStore } from '@app/state/convs-mgr/conversations/chats';
-import { MessagesQuery } from '@app/state/convs-mgr/conversations/messages';
+
 
 @Component({
   selector: 'app-chats-list',
@@ -59,7 +59,7 @@ export class ChatsListComponent implements AfterViewInit, OnInit
   @ViewChildren(MatPaginator) paginator: QueryList<MatPaginator>;
 
   constructor(private _chats$: ChatsStore,
-    private _msgsQuery$:MessagesQuery,
+    private _chatStore$:ChatsStore,
     private _activeChat$: ActiveChatConnectedStore,
     private cd: ChangeDetectorRef,
     _dS: DataService,
@@ -75,7 +75,7 @@ export class ChatsListComponent implements AfterViewInit, OnInit
 
     this._sbs.sink = this._activeChat$.get().pipe(filter(x => !!x)).subscribe((chat) => this.currentChat = chat);
 
-    this.chats$  = this._msgsQuery$.getChats();
+    this.chats$  = this._chatStore$.getChatsWithLatestMessageDate();
     this._sbs.sink = this.chats$.subscribe(chatList => this.getChats(chatList));
   }
 

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chats-list/chats-list.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chats-list/chats-list.component.ts
@@ -123,7 +123,7 @@ export class ChatsListComponent implements AfterViewInit, OnInit
     chatList.sort((a, b) => {
       const timestampA = lastMessageTimestamps[chatList.indexOf(a)];
       const timestampB = lastMessageTimestamps[chatList.indexOf(b)];
-      return timestampB.getTime() - timestampA.getTime();
+      return timestampB.getTime() - timestampA.getTime();// Compare timestamps and return the comparison result.
     });
   
     this.chats = chatList;

--- a/libs/state/convs-mgr/conversations/chats/src/lib/stores/chats.store.ts
+++ b/libs/state/convs-mgr/conversations/chats/src/lib/stores/chats.store.ts
@@ -105,6 +105,7 @@ export class ChatsStore extends DataStore<Chat>
     return this.get().pipe(
       mergeMap((chats) => {
         const dateObservables = chats.map((chat) => {
+          // Retrieve the latest message date for each chat
           return this.messagesQuery.getLatestMessageDate(chat.id).pipe(
             map((date) => ({
               ...chat,
@@ -114,10 +115,13 @@ export class ChatsStore extends DataStore<Chat>
         });
 
         return combineLatest(dateObservables).pipe(
+          // Sort chats based on the date of the latest message
           map((chatsWithDates) => {
             chatsWithDates.sort((a, b) => {
+              // If there's no lastMsg, place the chat at the end
               if (!a.lastMsg) return 1;
               if (!b.lastMsg) return -1;
+              // Sort based on the date of the latest message (more recent comes first)
               return b.lastMsg - a.lastMsg;
             });
             return chatsWithDates;
@@ -126,4 +130,5 @@ export class ChatsStore extends DataStore<Chat>
       })
     );
   }
+  
 }

--- a/libs/state/convs-mgr/conversations/chats/src/lib/stores/chats.store.ts
+++ b/libs/state/convs-mgr/conversations/chats/src/lib/stores/chats.store.ts
@@ -101,7 +101,7 @@ export class ChatsStore extends DataStore<Chat>
     }));
   }
 
-  getChatsWithLatestMessageDate() {
+  getOrderedChats() {
     return this.get().pipe(
       mergeMap((chats) => {
         const dateObservables = chats.map((chat) => {

--- a/libs/state/convs-mgr/conversations/chats/src/lib/stores/chats.store.ts
+++ b/libs/state/convs-mgr/conversations/chats/src/lib/stores/chats.store.ts
@@ -3,7 +3,7 @@ import { Injectable } from '@angular/core';
 import { Repository, DataService } from '@ngfi/angular';
 import { DataStore }  from '@ngfi/state';
 
-import { of } from 'rxjs'
+import { combineLatest, of } from 'rxjs'
 import { tap, throttleTime, switchMap, map, mergeMap } from 'rxjs/operators';
 
 import { Logger } from '@iote/bricks-angular';
@@ -16,6 +16,10 @@ import { Cursor } from '@app/model/convs-mgr/conversations/admin/system';
 import { StoriesStore } from '@app/state/convs-mgr/stories';
 import { ActiveOrgStore } from '@app/private/state/organisation/main';
 
+
+import { MessagesQuery } from '@app/state/convs-mgr/conversations/messages';
+
+
 @Injectable({
   providedIn: 'root'
 })
@@ -26,6 +30,7 @@ export class ChatsStore extends DataStore<Chat>
 
   private _activeOrg: Organisation;
   
+  
   // Question to dev's reviewing:
   //   Will this always get all the organisations?
   //     i.e. Even if no organisations need to be loaded for a specific piece of functionaly e.g. invites, do we still load all organisations?
@@ -34,6 +39,7 @@ export class ChatsStore extends DataStore<Chat>
   constructor(_org$$: ActiveOrgStore,
               private _repoFac: DataService,
               private _StoryStore$$: StoriesStore, 
+              private messagesQuery :MessagesQuery,
               _logger: Logger)
   {
     super("always", _logger);
@@ -93,5 +99,31 @@ export class ChatsStore extends DataStore<Chat>
       }
       return chatsRepo.update(chat)
     }));
+  }
+
+  getChatsWithLatestMessageDate() {
+    return this.get().pipe(
+      mergeMap((chats) => {
+        const dateObservables = chats.map((chat) => {
+          return this.messagesQuery.getLatestMessageDate(chat.id).pipe(
+            map((date) => ({
+              ...chat,
+              lastMsg: date
+            }))
+          );
+        });
+
+        return combineLatest(dateObservables).pipe(
+          map((chatsWithDates) => {
+            chatsWithDates.sort((a, b) => {
+              if (!a.lastMsg) return 1;
+              if (!b.lastMsg) return -1;
+              return b.lastMsg - a.lastMsg;
+            });
+            return chatsWithDates;
+          })
+        );
+      })
+    );
   }
 }

--- a/libs/state/convs-mgr/conversations/messages/src/lib/message-state.module.ts
+++ b/libs/state/convs-mgr/conversations/messages/src/lib/message-state.module.ts
@@ -1,14 +1,11 @@
 import { NgModule } from '@angular/core';
 import { InfiniteScrollModule } from '@ngfi/infinite-scroll';
 
-import { ChatsStateModule } from '@app/state/convs-mgr/conversations/chats';
-
 import { MessagesQuery } from './queries/messages.query';
 
 @NgModule({
   imports: [
     InfiniteScrollModule,
-    ChatsStateModule
   ],
   providers: [
     MessagesQuery

--- a/libs/state/convs-mgr/conversations/messages/src/lib/queries/messages.query.ts
+++ b/libs/state/convs-mgr/conversations/messages/src/lib/queries/messages.query.ts
@@ -90,8 +90,8 @@ export class MessagesQuery
             // Sort the chats based on the last message date in descending order
             chatsWithDates.sort((a, b) => {
               // Ensure that null dates (error cases) are placed at the end
-              if (a.lastMsg === null) return 1;
-              if (b.lastMsg === null) return -1;
+              if (!a.lastMsg) return 1;
+              if (!b.lastMsg) return -1;
               return b.lastMsg - a.lastMsg;
             });
             return chatsWithDates;

--- a/libs/state/convs-mgr/conversations/messages/src/lib/queries/messages.query.ts
+++ b/libs/state/convs-mgr/conversations/messages/src/lib/queries/messages.query.ts
@@ -84,7 +84,7 @@ export class MessagesQuery
           );
         });
   
-        // Use forkJoin to wait for all date observables to complete
+        // Use combine latest to wait for all date observables to complete
         return combineLatest(dateObservables).pipe(
           map((chatsWithDates) => {
             // Sort the chats based on the last message date in descending order

--- a/libs/state/convs-mgr/conversations/messages/src/lib/queries/messages.query.ts
+++ b/libs/state/convs-mgr/conversations/messages/src/lib/queries/messages.query.ts
@@ -1,7 +1,6 @@
 import { Injectable } from '@angular/core';
 
-import {  map, mergeMap } from 'rxjs/operators';
-import {  combineLatest} from 'rxjs';
+import {  map } from 'rxjs/operators';
 
 import { __DateFromStorage } from '@iote/time';
 import { Logger } from '@iote/bricks-angular';
@@ -12,7 +11,6 @@ import { Query } from '@ngfi/firestore-qbuilder';
 import { Chat } from '@app/model/convs-mgr/conversations/chats';
 import { Message } from '@app/model/convs-mgr/conversations/messages';
 
-import { ActiveChatStore, ChatsStore } from '@app/state/convs-mgr/conversations/chats';
 import { ActiveOrgStore } from '@app/private/state/organisation/main';
 
 
@@ -26,12 +24,9 @@ export class MessagesQuery
   private _activeChat: Chat;
   private orgId?: string;
 
-  constructor(
-                private _activeOrg: ActiveOrgStore,
-                _activeChat$: ActiveChatStore,
-               private _dataService: DataService,
-               private _chatStore : ChatsStore,
-               protected _logger: Logger)
+  constructor(private _activeOrg: ActiveOrgStore,
+              private _dataService: DataService,
+              protected _logger: Logger)
   {
     _activeOrg.get().subscribe(org => this.orgId = org.id);
   }
@@ -67,39 +62,12 @@ export class MessagesQuery
     return messagesRepo$.create(message, Date.now().toString());
   }
 
+  // get(index: number, n: number): Observable<ChatMessage[]>
+  // {
 
-  getChats() {
-    const chatsList = this._chatStore.get();
-  
-    return chatsList.pipe(
-      // Use mergeMap to map each chat to an observable of its latest message date
-      mergeMap((chats) => {
-        // Create an array of observables to fetch the latest message date for each chat
-        const dateObservables = chats.map((chat) => {
-          return this.getLatestMessageDate(chat.id).pipe(
-            map((date) => ({
-              ...chat,
-              lastMsg: date,
-            }))
-          );
-        });
-  
-        // Use combine latest to wait for all date observables to complete
-        return combineLatest(dateObservables).pipe(
-          map((chatsWithDates) => {
-            // Sort the chats based on the last message date in descending order
-            chatsWithDates.sort((a, b) => {
-              // Ensure that null dates (error cases) are placed at the end
-              if (!a.lastMsg) return 1;
-              if (!b.lastMsg) return -1;
-              return b.lastMsg - a.lastMsg;
-            });
-            return chatsWithDates;
-          })
-        );
-      })
-    );
-  }
-  
+  //   return this._qRepo.getDocuments(new Query().orderBy('date', 'desc')
+  //                                              .skipTake(index, n))
+  // }
+ 
 }
 

--- a/libs/state/convs-mgr/conversations/messages/src/lib/queries/messages.query.ts
+++ b/libs/state/convs-mgr/conversations/messages/src/lib/queries/messages.query.ts
@@ -69,9 +69,6 @@ export class MessagesQuery
 
 
   getChats() {
-    if (!this.orgId) {
-      throw new Error('Organization ID is not set. Call setOrgId(orgId) first.');
-    }
     const chatsList = this._chatStore.get();
   
     return chatsList.pipe(


### PR DESCRIPTION
# Description

As a user, I want to see the most recent chat displayed first.
This pull request addresses the user story by implementing default ordering by the newest in the chat list. With this enhancement, users will have the most recent chats displayed at the top of the list, ensuring that they can easily access their latest interactions with the content.
The list of chats should be ordered with the first chat being the newest, representing the most recent interaction with the content.

## Type of change

- [X] New feature (non-breaking change which adds functionality)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

