### PR TITLE
🔧 CLM-64 A Link That Navigates User From Chats To Profile

### DIFF
--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.html
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.html
@@ -8,10 +8,8 @@
       <span class="user-char" *ngIf="chat.name">{{getUserName(chat.name)}}</span>
     </div>
 
-    <div class="chat-title-txt">
-      <a [routerLink]="['/learners/', extractedLearnerId ]"> 
+    <div class="chat-title-txt" (click)="navigateToLearner()">
         <span *ngIf="chat.name" class="chat-name"> {{ chat.name.toLowerCase() }} </span>
-      </a>  
       <span title="phoneNumber" class="chat-number"> +{{ chat.phoneNumber }} </span>
     </div>
   </div>

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.html
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.html
@@ -9,7 +9,11 @@
     </div>
 
     <div class="chat-title-txt" (click)="navigateToLearner()">
-        <span *ngIf="chat.name" class="chat-name"> {{ chat.name.toLowerCase() }} </span>
+        <span *ngIf="chat.name" class="chat-name" 
+        [style.color]="chatNameColor" 
+        (mouseenter)="updateChatNameColor()"
+        (mouseleave)="resetChatNameColor()"
+        > {{ chat.name.toLowerCase() }} </span>
       <span title="phoneNumber" class="chat-number"> +{{ chat.phoneNumber }} </span>
     </div>
   </div>

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.html
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.html
@@ -9,11 +9,12 @@
     </div>
 
     <div class="chat-title-txt">
-      <span *ngIf="chat.name" class="chat-name"> {{ chat.name.toLowerCase() }} </span>
+      <a [routerLink]="['/learners/', extractedLearnerId ]"> 
+        <span *ngIf="chat.name" class="chat-name"> {{ chat.name.toLowerCase() }} </span>
+      </a>  
       <span title="phoneNumber" class="chat-number"> +{{ chat.phoneNumber }} </span>
     </div>
   </div>
-
   <div class="fab-holder" fxFlex="30" fxLayout="row" fxLayoutAlign="end">
 
     <div *ngIf="userClass" class="header__item">

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.scss
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.scss
@@ -52,7 +52,7 @@
 }
 
 .chat-title-txt{
-  cursor: pointer;
+  cursor: pointer !important;
   display: grid;
   gap: 5px;
   grid-template-rows: 2;
@@ -61,9 +61,7 @@
     font-size: 1.1rem;
     font-weight: 400;
   }
-  .chat-name:hover{
-    color: #3E788A;
-  }
+ 
   
   .chat-number {
     color: #707070;

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.scss
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.scss
@@ -39,6 +39,10 @@
   font-size: 16px;
   text-transform: capitalize;
   font-weight: 600;
+  a{
+    text-decoration: none;
+    color: inherit;
+  }
 }
 
 .user-tooltip {

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.scss
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.scss
@@ -45,11 +45,14 @@
   }
 }
 
+
+
 .user-tooltip {
   font-size: 32px !important;
 }
 
 .chat-title-txt{
+  cursor: pointer;
   display: grid;
   gap: 5px;
   grid-template-rows: 2;
@@ -58,12 +61,16 @@
     font-size: 1.1rem;
     font-weight: 400;
   }
+  .chat-name:hover{
+    color: #3E788A;
+  }
   
   .chat-number {
     color: #707070;
     font-weight: 400;
     font-size: .8rem;
   }
+  
 }
 
 .inactive {

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -91,7 +91,7 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
       .subscribe(
         (learners: EnrolledEndUser[]) => {
             const learner = learners[0];
-            //used this check since learner.id is a nullable string
+            // Check if learner.id is defined before passing it a string since learner.id is nullable
             if (learner.id !== undefined && learner.id !== null) {
               this.extractedLearnerId = learner.id 
             } else {

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -53,6 +53,8 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
 
   avatarBgColor: string;
 
+  extractedLearnerId: any;// This variable will be used to store the ID of a learner extracted from enrolled learners.
+
   constructor(private _snackBar: MatSnackBar,
               private userService: UserService<iTalUser>,
               private _backendService: BackendService,

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -24,6 +24,7 @@ import { AngularFireFunctions } from '@angular/fire/compat/functions';
 import { Chat, ChatStatus } from '@app/model/convs-mgr/conversations/chats';
 import { EndUserPosition } from '@app/model/convs-mgr/conversations/admin/system';
 import { SpinnerService } from '@app/features/convs-mgr/conversations/messaging';
+import { EnrolledLearnersService } from '@app/state/convs-mgr/learners';
 
 import { MoveChatModal } from '../../modals/move-chat-modal/move-chat-modal.component';
 import { StashChatModal } from '../../modals/stash-chat-modal/stash-chat-modal.component';

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -10,7 +10,7 @@ import {
 import { Router } from '@angular/router';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 
-import { first, from, tap } from 'rxjs';
+import { catchError, first, from, tap } from 'rxjs';
 import { SubSink } from 'subsink';
 
 import { BackendService, UserService } from '@ngfi/angular';
@@ -84,17 +84,43 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
         this.moveChatDialogRef = null as any;
       }
     }
+    console.log("chat",this.chat.id)
+    console.log("platform",PlatformType.WhatsApp)
 
-    // Subscribe to the getAllLearners$ Observable from _enrolledLearners service
+    console.log('Before calling getLearnerId$');
+
     this._enrolledLearners
       .getLearnerId$(PlatformType.WhatsApp, this.chat.id)
-      .pipe(first())
-      .subscribe((learners: EnrolledEndUser[]) => {
-        if (learners.length > 0) {
-          const learner = learners[0]; // getting the first learner
-          this.extractedLearnerId = learner.id
+      .pipe(
+        catchError((error) => {
+          console.error('Error fetching enrolled learners:', error);
+          return [];
+        }),
+        first()
+      )
+      .subscribe(
+        (learners: EnrolledEndUser[]) => {
+          console.log('Inside subscribe'); // Log when subscribe is called
+          if (learners.length > 0) {
+            const learner = learners[0];
+            this.extractedLearnerId = learner.id;
+            console.log('Extracted learner ID:', this.extractedLearnerId);
+          } else {
+            console.log('No learners emitted');
+          }
+        },
+        (error) => {
+          console.error('Error in subscribe:', error);
+        },
+        () => {
+          console.log('Observable completed');
         }
-      });
+      );
+    
+    console.log('After calling getLearnerId$');
+    
+
+
   }
 
   formatDate = (date: Timestamp | Date) => __FormatDateFromStorage(date);

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -45,6 +45,7 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
   @Input() currentPosition: EndUserPosition;
 
   private _sbs = new SubSink();
+  extractedLearnerId: string | undefined;// This variable will be used to store the ID of a learner extracted from enrolled learners.
 
   confirmDialogRef: MatDialogRef<ConfirmActionModal>;
   moveChatDialogRef: MatDialogRef<MoveChatModal>;

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -84,43 +84,20 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
         this.moveChatDialogRef = null as any;
       }
     }
-    console.log("chat",this.chat.id)
-    console.log("platform",PlatformType.WhatsApp)
-
-    console.log('Before calling getLearnerId$');
 
     this._enrolledLearners
       .getLearnerId$(PlatformType.WhatsApp, this.chat.id)
-      .pipe(
-        catchError((error) => {
-          console.error('Error fetching enrolled learners:', error);
-          return [];
-        }),
-        first()
-      )
       .subscribe(
         (learners: EnrolledEndUser[]) => {
-          console.log('Inside subscribe'); // Log when subscribe is called
+          console.log({learners}); // Log when subscribe is called
           if (learners.length > 0) {
             const learner = learners[0];
             this.extractedLearnerId = learner.id;
-            console.log('Extracted learner ID:', this.extractedLearnerId);
           } else {
             console.log('No learners emitted');
           }
         },
-        (error) => {
-          console.error('Error in subscribe:', error);
-        },
-        () => {
-          console.log('Observable completed');
-        }
       );
-    
-    console.log('After calling getLearnerId$');
-    
-
-
   }
 
   formatDate = (date: Timestamp | Date) => __FormatDateFromStorage(date);

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -92,11 +92,7 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
         (learners: EnrolledEndUser[]) => {
             const learner = learners[0];
             // Check if learner.id is defined before passing it a string since learner.id is nullable
-            if (learner.id !== undefined) {
-              this.extractedLearnerId = learner.id.toString() 
-            } else {
-              this.extractedLearnerId = ''; // Set to an empty string or null,
-            }
+              this.extractedLearnerId = learner.id ?? ''
         },
       );
   }

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -10,7 +10,7 @@ import {
 import { Router } from '@angular/router';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 
-import { catchError, first, from, tap } from 'rxjs';
+import {  from, tap } from 'rxjs';
 import { SubSink } from 'subsink';
 
 import { BackendService, UserService } from '@ngfi/angular';
@@ -25,13 +25,14 @@ import { Chat, ChatStatus } from '@app/model/convs-mgr/conversations/chats';
 import { EndUserPosition, PlatformType } from '@app/model/convs-mgr/conversations/admin/system';
 import { SpinnerService } from '@app/features/convs-mgr/conversations/messaging';
 import { EnrolledLearnersService } from '@app/state/convs-mgr/learners';
+import { EnrolledEndUser } from '@app/model/convs-mgr/learners';
 
 import { MoveChatModal } from '../../modals/move-chat-modal/move-chat-modal.component';
 import { StashChatModal } from '../../modals/stash-chat-modal/stash-chat-modal.component';
 import { ConfirmActionModal } from '../../modals/confirm-action-modal/confirm-action-modal.component';
 import { ViewDetailsModal } from '../../modals/view-details-modal/view-details-modal.component';
 import { GET_RANDOM_COLOR, GET_USER_AVATAR } from '../../providers/avatar.provider';
-import { EnrolledEndUser } from '@app/model/convs-mgr/learners';
+
 
 @Component({
   selector: 'app-chat-detail-header',
@@ -89,13 +90,9 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
       .getLearnerId$(PlatformType.WhatsApp, this.chat.id)
       .subscribe(
         (learners: EnrolledEndUser[]) => {
-          console.log({learners}); // Log when subscribe is called
-          if (learners.length > 0) {
             const learner = learners[0];
             this.extractedLearnerId = learner.id;
-          } else {
-            console.log('No learners emitted');
-          }
+          
         },
       );
   }

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -56,7 +56,7 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
 
   avatarBgColor: string;
 
-  extractedLearnerId: any;// This variable will be used to store the ID of a learner extracted from enrolled learners.
+
 
   constructor(private _snackBar: MatSnackBar,
               private userService: UserService<iTalUser>,

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -78,6 +78,15 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
         this.moveChatDialogRef = null as any;
       }
     }
+
+    // Subscribe to the getAllLearners$ Observable from _enrolledLearners service
+    this._enrolledLearners.getAllLearners$().subscribe((learners) => {
+      learners.forEach((learner) => {
+        if (this.chat.id == learner.whatsappUserId) {
+          this.extractedLearnerId = learner.id;
+        }
+      });
+    });
   }
 
   formatDate = (date: Timestamp | Date) => __FormatDateFromStorage(date);

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -275,6 +275,10 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
   getUserName = (name: string) => GET_USER_AVATAR(name);
   randomColor = () => GET_RANDOM_COLOR();
 
+  navigateToLearner(){
+    this._router.navigate([`/learners/${this.extractedLearnerId }`]);
+  }
+
   ngOnDestroy() {
     this._sbs.unsubscribe();
   }

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -91,8 +91,9 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
       .subscribe(
         (learners: EnrolledEndUser[]) => {
             const learner = learners[0];
+            //used this check since learner.id is a nullable string
             if (learner.id !== undefined && learner.id !== null) {
-              this.extractedLearnerId = learner.id.toString(); // Convert to string
+              this.extractedLearnerId = learner.id 
             } else {
               this.extractedLearnerId = ''; // Set to an empty string or null,
             }

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -31,6 +31,7 @@ import { StashChatModal } from '../../modals/stash-chat-modal/stash-chat-modal.c
 import { ConfirmActionModal } from '../../modals/confirm-action-modal/confirm-action-modal.component';
 import { ViewDetailsModal } from '../../modals/view-details-modal/view-details-modal.component';
 import { GET_RANDOM_COLOR, GET_USER_AVATAR } from '../../providers/avatar.provider';
+import { EnrolledEndUser } from '@app/model/convs-mgr/learners';
 
 @Component({
   selector: 'app-chat-detail-header',

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -92,8 +92,8 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
         (learners: EnrolledEndUser[]) => {
             const learner = learners[0];
             // Check if learner.id is defined before passing it a string since learner.id is nullable
-            if (learner.id !== undefined && learner.id !== null) {
-              this.extractedLearnerId = learner.id 
+            if (learner.id !== undefined) {
+              this.extractedLearnerId = learner.id.toString() 
             } else {
               this.extractedLearnerId = ''; // Set to an empty string or null,
             }

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -63,6 +63,7 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
               private _afsF: AngularFireFunctions,
               private _dialog: MatDialog,
               private _spinner: SpinnerService,
+              private _enrolledLearners: EnrolledLearnersService,
   ) {
     this._sbs.sink = this.userService.getUser().subscribe((user) => (this.user = user));
     this.avatarBgColor = this.randomColor();

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -10,7 +10,7 @@ import {
 import { Router } from '@angular/router';
 import { MatDialog, MatDialogRef } from '@angular/material/dialog';
 
-import { from, tap } from 'rxjs';
+import { first, from, tap } from 'rxjs';
 import { SubSink } from 'subsink';
 
 import { BackendService, UserService } from '@ngfi/angular';
@@ -22,7 +22,7 @@ import { Story } from '@app/model/convs-mgr/stories/main';
 import { MatSnackBar } from '@angular/material/snack-bar';
 import { AngularFireFunctions } from '@angular/fire/compat/functions';
 import { Chat, ChatStatus } from '@app/model/convs-mgr/conversations/chats';
-import { EndUserPosition } from '@app/model/convs-mgr/conversations/admin/system';
+import { EndUserPosition, PlatformType } from '@app/model/convs-mgr/conversations/admin/system';
 import { SpinnerService } from '@app/features/convs-mgr/conversations/messaging';
 import { EnrolledLearnersService } from '@app/state/convs-mgr/learners';
 

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -84,13 +84,16 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
     }
 
     // Subscribe to the getAllLearners$ Observable from _enrolledLearners service
-    this._enrolledLearners.getAllLearners$().subscribe((learners) => {
-      learners.forEach((learner) => {
-        if (this.chat.id == learner.whatsappUserId) {
-          this.extractedLearnerId = learner.id;
+    this._enrolledLearners
+      .getLearnerId$(PlatformType.WhatsApp, this.chat.id)
+      .pipe(first())
+      .subscribe((learners: EnrolledEndUser[]) => {
+        if (learners.length > 0) {
+          const learner = learners[0]; // Assuming you want the first learner
+          console.log("Learner ID:", learner.id);
+          this.extractedLearnerId = learner.id
         }
       });
-    });
   }
 
   formatDate = (date: Timestamp | Date) => __FormatDateFromStorage(date);

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -57,6 +57,8 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
 
   avatarBgColor: string;
 
+  chatNameColor = '#000000'; 
+
 
 
   constructor(private _snackBar: MatSnackBar,
@@ -96,6 +98,7 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
         },
       );
   }
+  
 
   formatDate = (date: Timestamp | Date) => __FormatDateFromStorage(date);
 
@@ -277,6 +280,15 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
 
   navigateToLearner(){
     this._router.navigate([`/learners/${this.extractedLearnerId }`]);
+  }
+
+  updateChatNameColor() {
+    // Update chatNameColor based on avatarBgColor or any other logic you need
+    this.chatNameColor = this.avatarBgColor;
+  }
+  resetChatNameColor() {
+    // Reset chatNameColor to the original color when not hovering
+    this.chatNameColor= '#000000'
   }
 
   ngOnDestroy() {

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -91,8 +91,7 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
       .pipe(first())
       .subscribe((learners: EnrolledEndUser[]) => {
         if (learners.length > 0) {
-          const learner = learners[0]; // Assuming you want the first learner
-          console.log("Learner ID:", learner.id);
+          const learner = learners[0]; // getting the first learner
           this.extractedLearnerId = learner.id
         }
       });

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-detail-header/chat-detail-header.component.ts
@@ -47,7 +47,7 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
   @Input() currentPosition: EndUserPosition;
 
   private _sbs = new SubSink();
-  extractedLearnerId: string | undefined;// This variable will be used to store the ID of a learner extracted from enrolled learners.
+  extractedLearnerId: string;// This variable will be used to store the ID of a learner extracted from enrolled learners.
 
   confirmDialogRef: MatDialogRef<ConfirmActionModal>;
   moveChatDialogRef: MatDialogRef<MoveChatModal>;
@@ -91,8 +91,11 @@ export class ChatDetailHeaderComponent implements OnChanges, OnDestroy {
       .subscribe(
         (learners: EnrolledEndUser[]) => {
             const learner = learners[0];
-            this.extractedLearnerId = learner.id;
-          
+            if (learner.id !== undefined && learner.id !== null) {
+              this.extractedLearnerId = learner.id.toString(); // Convert to string
+            } else {
+              this.extractedLearnerId = ''; // Set to an empty string or null,
+            }
         },
       );
   }

--- a/libs/state/convs-mgr/end-users/src/lib/store/end-user.store.ts
+++ b/libs/state/convs-mgr/end-users/src/lib/store/end-user.store.ts
@@ -7,7 +7,7 @@ import { tap, throttleTime, switchMap } from 'rxjs/operators';
 
 import { Logger } from '@iote/bricks-angular';
 
-import { ActiveOrgStore } from '@app/state/organisation';
+import { ActiveOrgStore } from '@app/private/state/organisation/main';
 
 import { Organisation } from '@app/model/organisation';
 import { EndUser } from '@app/model/convs-mgr/conversations/chats';

--- a/libs/state/convs-mgr/learners/src/lib/services/learners.service.ts
+++ b/libs/state/convs-mgr/learners/src/lib/services/learners.service.ts
@@ -6,6 +6,7 @@ import { EnrolledEndUser } from '@app/model/convs-mgr/learners';
 import { EndUserService } from '@app/state/convs-mgr/end-users';
 
 import { LearnersStore } from '../store/learners.store';
+import { PlatformType } from '@app/model/convs-mgr/conversations/admin/system';
 
 @Injectable({
   providedIn: 'root',
@@ -54,5 +55,8 @@ export class EnrolledLearnersService {
 
   updateLearner$(learner: EnrolledEndUser) {
     return this._enrolledLearners$$.update(learner);
+  }
+  getLearnerId$(platform: PlatformType, id: string ){
+    return this._enrolledLearners$$.getLearnerByPlatfromId(platform, id)
   }
 }

--- a/libs/state/convs-mgr/learners/src/lib/services/learners.service.ts
+++ b/libs/state/convs-mgr/learners/src/lib/services/learners.service.ts
@@ -4,9 +4,10 @@ import { map, switchMap, of, combineLatest } from 'rxjs';
 
 import { EnrolledEndUser } from '@app/model/convs-mgr/learners';
 import { EndUserService } from '@app/state/convs-mgr/end-users';
+import { PlatformType } from '@app/model/convs-mgr/conversations/admin/system';
 
 import { LearnersStore } from '../store/learners.store';
-import { PlatformType } from '@app/model/convs-mgr/conversations/admin/system';
+
 
 @Injectable({
   providedIn: 'root',

--- a/libs/state/convs-mgr/learners/src/lib/store/learners.store.ts
+++ b/libs/state/convs-mgr/learners/src/lib/store/learners.store.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@angular/core';
 import { Repository, DataService } from '@ngfi/angular';
 import { DataStore }  from '@ngfi/state';
 
-import { of } from 'rxjs'
+import { Observable, of } from 'rxjs'
 import { tap, throttleTime, switchMap } from 'rxjs/operators';
 
 import { Logger } from '@iote/bricks-angular';
@@ -11,6 +11,8 @@ import { ActiveOrgStore } from '@app/state/organisation';
 
 import { Organisation } from '@app/model/organisation';
 import { EnrolledEndUser } from '@app/model/convs-mgr/learners';
+import { PlatformType } from '@app/model/convs-mgr/conversations/admin/system';
+import { Query } from '@ngfi/firestore-qbuilder';
 
 @Injectable()
 export class LearnersStore extends DataStore<EnrolledEndUser>
@@ -48,5 +50,12 @@ export class LearnersStore extends DataStore<EnrolledEndUser>
     this._sbS.sink = data$.subscribe(properties => {
       this.set(properties, 'UPDATE - FROM DB');
     });
+  }
+  getLearnerByPlatfromId(platform: PlatformType, id: string): Observable<EnrolledEndUser[]> {
+    if (platform === PlatformType.WhatsApp) {
+      return this._activeRepo.getDocuments(new Query().where('whatsappUserId', '==', id));
+    } else {
+      return this._activeRepo.getDocuments(new Query().where('messengerUserId', '==', id));
+    }
   }
 }

--- a/libs/state/convs-mgr/learners/src/lib/store/learners.store.ts
+++ b/libs/state/convs-mgr/learners/src/lib/store/learners.store.ts
@@ -1,6 +1,8 @@
 import { Injectable } from '@angular/core';
+
 import { Repository, DataService } from '@ngfi/angular';
 import { DataStore }  from '@ngfi/state';
+import { Query } from '@ngfi/firestore-qbuilder';
 
 import { Observable, of } from 'rxjs'
 import { tap, throttleTime, switchMap } from 'rxjs/operators';
@@ -12,7 +14,6 @@ import { ActiveOrgStore } from '@app/private/state/organisation/main';
 import { Organisation } from '@app/model/organisation';
 import { EnrolledEndUser } from '@app/model/convs-mgr/learners';
 import { PlatformType } from '@app/model/convs-mgr/conversations/admin/system';
-import { Query } from '@ngfi/firestore-qbuilder';
 
 @Injectable()
 export class LearnersStore extends DataStore<EnrolledEndUser>

--- a/libs/state/convs-mgr/learners/src/lib/store/learners.store.ts
+++ b/libs/state/convs-mgr/learners/src/lib/store/learners.store.ts
@@ -7,7 +7,7 @@ import { tap, throttleTime, switchMap } from 'rxjs/operators';
 
 import { Logger } from '@iote/bricks-angular';
 
-import { ActiveOrgStore } from '@app/state/organisation';
+import { ActiveOrgStore } from '@app/private/state/organisation/main';
 
 import { Organisation } from '@app/model/organisation';
 import { EnrolledEndUser } from '@app/model/convs-mgr/learners';


### PR DESCRIPTION
# Description

his pull request introduces a user-friendly feature that allows users to conveniently navigate to a learner's profile page directly from within the chat interface. Instead of having to access the Students tab and navigate through multiple pages, users can now click on the learner's name r at the top of the chat, and it will open the corresponding learner's profile page.

This enhancement provides users with quick access to detailed learner information, improving their overall experience and efficiency.



## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
Access the chat interface.
Identify a learner's name  displayed at the top.
Click on the learner's name .



# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings

