### PR TITLE
:lipstick: create distinction between card and background

### DIFF
--- a/libs/elements/theming/_variables.scss
+++ b/libs/elements/theming/_variables.scss
@@ -14,6 +14,7 @@
   --convs-mgr-color-primary-pink: #ed576b;
   --convs-mgr-color-primary-dark-blue: #151B4A;
   --convs-mgr-color-primary-grey: #666;
+  --convs-mgr-color-primary-light-grey: #f6f6f6;
   --convs-mgr-color-text-black: #263446;
   --convs-mgr-color-text-white: #fff;
   --convs-mgr-color-nav-inactive: #C6CDD8;

--- a/libs/features/convs-mgr/home/src/lib/components/home-courses/home-courses.component.scss
+++ b/libs/features/convs-mgr/home/src/lib/components/home-courses/home-courses.component.scss
@@ -15,14 +15,14 @@
 
 .badge {
   display: inline-block;
-  padding: 0.25em 0.4em;
+  padding: 0.5em 0.9em;
   font-size: .9em;
   font-weight: 400;
   line-height: 1;
   text-align: center;
   white-space: nowrap;
   vertical-align: baseline;
-  border-radius: 0.25rem;
+  border-radius: 3.125rem;
   color: black;
   background-color: #DADADA;
 
@@ -31,6 +31,10 @@
   }
 
   &.telegram {
+    background-color: #6CD4FA;
+  }
+
+  &.messenger {
     background-color: #6CD4FA;
   }
 }

--- a/libs/features/convs-mgr/home/src/lib/components/home-courses/home-courses.component.scss
+++ b/libs/features/convs-mgr/home/src/lib/components/home-courses/home-courses.component.scss
@@ -1,7 +1,7 @@
 .cards .assessment-card, .cards .new-course {
   height: 250px;
   padding: 20px;
-  background-color: #fff;
+  background-color: var(--convs-mgr-color-primary-white);
   border-radius: 10px;
 }
 

--- a/libs/features/convs-mgr/home/src/lib/components/home-courses/home-courses.component.scss
+++ b/libs/features/convs-mgr/home/src/lib/components/home-courses/home-courses.component.scss
@@ -1,7 +1,7 @@
 .cards .assessment-card, .cards .new-course {
   height: 250px;
   padding: 20px;
-  background-color: white;
+  background-color: #fff;
   border-radius: 10px;
 }
 

--- a/libs/features/convs-mgr/home/src/lib/components/home-courses/home-courses.component.ts
+++ b/libs/features/convs-mgr/home/src/lib/components/home-courses/home-courses.component.ts
@@ -6,35 +6,30 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./home-courses.component.scss'],
 })
 export class HomeCoursesComponent implements OnInit {
-
   courses = [
     {
-      id: "1",
-      name: " Course 1 ",
-      isPublished: false,
-      platform: 'whatsapp'
+      id: '1',
+      name: 'ITC - Introduction to scouting',
+      isPublished: true,
+      platform: 'whatsapp',
     },
     {
-      id: "2",
-      name: " Introduction to scouting ",
+      id: '2',
+      name: 'ITC - Introduction to scouting ',
       isPublished: true,
-      platform: 'telegram'
+      platform: 'messenger',
     },
     {
-      id: "3",
-      name: " Introduction to scouting ",
+      id: '3',
+      name: 'PTC - Preliminary scouting',
       isPublished: true,
-      platform: 'whatsapp'
+      platform: 'in progress',
     },
-  ]
-  constructor() { }
+  ];
+  constructor() {}
 
-  ngOnInit(): void { }
+  ngOnInit(): void {}
 
-  openCourse(courseId: string) {
-
-  }
-  openDeleteModal(course: any) {
-
-  }
+  openCourse(courseId: string) {}
+  openDeleteModal(course: any) {}
 }

--- a/libs/features/convs-mgr/home/src/lib/pages/home/home.page.scss
+++ b/libs/features/convs-mgr/home/src/lib/pages/home/home.page.scss
@@ -1,6 +1,6 @@
 .home-page {
 	padding: 30px;
-	background-color: #F6F6F6;
+	background-color: var(--convs-mgr-color-primary-light-grey);
 }
 
 

--- a/libs/features/convs-mgr/home/src/lib/pages/home/home.page.scss
+++ b/libs/features/convs-mgr/home/src/lib/pages/home/home.page.scss
@@ -1,5 +1,6 @@
 .home-page {
 	padding: 30px;
+	background-color: #F6F6F6;
 }
 
 


### PR DESCRIPTION
# Description
This Pr creates a clear distinction between the card and home background

Fixes #616 

# Screenshot (optional)
![card-background](https://github.com/italanta/elewa/assets/65117575/73235f1a-e6af-4a54-923d-ca6fae66d4b2)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
