### PR TITLE
🎨 💄 Tooltips On Collapsed Side Navigation #618

### DIFF
--- a/libs/elements/layout/page-convl/src/lib/components/convl-sidemenu/convl-sidemenu.component.html
+++ b/libs/elements/layout/page-convl/src/lib/components/convl-sidemenu/convl-sidemenu.component.html
@@ -22,7 +22,7 @@
             <!-- Section Dashboard -->
             <li routerLink="/home" routerLinkActive="active" class="menu-item">
               <a>
-                <span class="menu-icon">
+                <span class="menu-icon" matToolTip="home">
                   <img src="assets/icons/home-stroked.svg" alt="">
                 </span>
                 <span *ngIf="isExpanded" class="menu-title">
@@ -33,7 +33,7 @@
             <!-- Section Bots -->
             <li *hasViewAccess="CAN_ACCESS_BOTS" routerLink="/stories" routerLinkActive="active" class="menu-item">
               <a>
-                <span class="menu-icon">
+                <span class="menu-icon" >
                   <img src="assets/icons/bots-stroked.svg" alt="">
                 </span>
                 <span *ngIf="isExpanded" class="menu-title">

--- a/libs/elements/layout/page-convl/src/lib/components/convl-sidemenu/convl-sidemenu.component.html
+++ b/libs/elements/layout/page-convl/src/lib/components/convl-sidemenu/convl-sidemenu.component.html
@@ -22,7 +22,7 @@
             <!-- Section Dashboard -->
             <li routerLink="/home" routerLinkActive="active" class="menu-item">
               <a>
-                <span class="menu-icon" matToolTip="home">
+                <span class="menu-icon"matTooltip="Home" >
                   <img src="assets/icons/home-stroked.svg" alt="">
                 </span>
                 <span *ngIf="isExpanded" class="menu-title">
@@ -33,7 +33,7 @@
             <!-- Section Bots -->
             <li *hasViewAccess="CAN_ACCESS_BOTS" routerLink="/stories" routerLinkActive="active" class="menu-item">
               <a>
-                <span class="menu-icon" >
+                <span class="menu-icon"matToolTip="Bots" >
                   <img src="assets/icons/bots-stroked.svg" alt="">
                 </span>
                 <span *ngIf="isExpanded" class="menu-title">
@@ -44,7 +44,7 @@
             <!-- Section Analytics -->
             <li *hasViewAccess="CAN_ACCESS_ANALYTICS" routerLink="/analytics/dashboard" routerLinkActive="active" class="menu-item">
               <a>
-                <span class="menu-icon">
+                <span class="menu-icon"matTooltip="Analytics" >
                   <img src="assets/icons/insights-stroked.svg" alt="">
                 </span>
                 <span *ngIf="isExpanded" class="menu-title">
@@ -55,7 +55,7 @@
             <!-- Chats sections -->
             <li *hasViewAccess="CAN_ACCESS_CHATS" class="menu-item" routerLink="/chats" routerLinkActive="active">
               <a>
-                <span class="menu-icon">
+                <span class="menu-icon"matTooltip="Chats">
                   <img src="assets/icons/chats-stroked.svg" alt="">
                 </span>
                 <span *ngIf="isExpanded" class="menu-title">
@@ -68,7 +68,7 @@
             <li *hasViewAccess="CAN_ACCESS_ASSESSMENTS" class="menu-item" routerLink="/assessments"
               routerLinkActive="active">
               <a>
-                <span class="menu-icon">
+                <span class="menu-icon" matTooltip="Asssessments">
                   <img src="assets/icons/assessments-stroked.svg" alt="">
                 </span>
                 <span *ngIf="isExpanded" class="menu-title">
@@ -80,7 +80,7 @@
             <!-- Learners sections -->
             <li *hasViewAccess="CAN_ACCESS_LEARNERS" class="menu-item" routerLink="/learners" routerLinkActive="active">
               <a>
-                <span class="menu-icon">
+                <span class="menu-icon" matTooltip="Learners">
                   <img src="assets/icons/learners-stroked.svg" alt="">
                 </span>
                 <span *ngIf="isExpanded" class="menu-title" routerLink="/budgets" routerLinkActive="active">
@@ -91,7 +91,7 @@
 
             <li *hasViewAccess="CAN_ACCESS_SETTINGS" class="menu-item" routerLink="/settings" routerLinkActive="active">
               <a>
-                <span class="menu-icon">
+                <span class="menu-icon"matTooltip="Settings">
                   <img src="assets/icons/settings-stroked.svg" alt="">
                 </span>
                 <span *ngIf="isExpanded" class="menu-title">


### PR DESCRIPTION
# Description

As a user i want the collapsed side navigation to provide me with tab labels when i hover my cursor over an icon.

#618

## created tab labels for the side-menu icons

# Screenshot (optional)
![Screenshot from 2023-09-27 20-27-28](https://github.com/italanta/elewa/assets/93130620/26e21a0d-7851-4b48-a895-ae8d84416479)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**: (optional)
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
