### PR TITLE
:recycle: Space between phone and number

### DIFF
--- a/apps/conv-learning-manager/src/assets/i18n/en.json
+++ b/apps/conv-learning-manager/src/assets/i18n/en.json
@@ -482,7 +482,7 @@
   "LEARNERS":{
     "TABLE-HEADER": {
       "NAME": "Name",
-      "PHONE-NUMBER": "PhoneNumber",
+      "PHONE-NUMBER": "Phone Number",
       "COURSE": "Course",
       "CLASS": "Class",
       "STATUS": "Status"


### PR DESCRIPTION
# Description

- Added spacing in the PhoneNumber header.

Fixes #724
## Formatting

- [X] New feature (non-breaking change which adds functionality)


# Screenshot (optional)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] My changes generate no new warnings

