### PR TITLE
:art:  CLM-248 chats user name initial background should change colour if the learner is different

### DIFF
--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-card/chat-card.component.html
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-card/chat-card.component.html
@@ -1,6 +1,6 @@
 <div class="card" [class.selected]="currentChat.id === chat.id" fxLayout="row" fxLayoutAlign="start center"
   fxLayoutGap="16px">
-  <div class="avatar" [ngStyle]="{'background-color':chat.name ? chatAvatarColor : '#3E788A'}" [class.new-msg]="chat.awaitingResponse">
+  <div class="avatar" [ngStyle]="{'background-color': chatAvatarColor }" [class.new-msg]="chat.awaitingResponse">
     <div *ngIf="!chat.name">
      <span style="color: white;">UU</span>
     </div>

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-card/chat-card.component.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-card/chat-card.component.ts
@@ -52,10 +52,10 @@ export class ChatCardComponent implements OnChanges, AfterViewInit, OnDestroy
                                     this._msgsQuery$.getLatestMessageDate(this.chat.id)])
                           .pipe(tap(([variables, date]) => {
                                   this.chat.name = variables?.name ?? '';
-                                  this.chatAvatarColor = GET_RANDOM_COLOR();
                                   this.lastMessageDate = TIME_AGO(date.seconds);
                                 }))
                           .subscribe();
+    this.chatAvatarColor = GET_RANDOM_COLOR();
   }
 
   getClass()

--- a/libs/features/convs-mgr/conversations/chats/src/lib/providers/avatar.provider.ts
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/providers/avatar.provider.ts
@@ -1,4 +1,10 @@
-export const GET_RANDOM_COLOR = () => `#${Math.floor(Math.random()*16777215).toString(16)}`;
+export const GET_RANDOM_COLOR = () => {
+  let color;
+  do {
+    color = `#${Math.floor(Math.random() * 16777215).toString(16)}`;
+  } while (color === "#FFFFFF");
+  return color;
+};
 
 export function GET_USER_AVATAR(name: string) {
   if (!name) return '';


### PR DESCRIPTION

Fixes chats user name initial background should change colour if the learner is different.
CLM-248

![image](https://github.com/italanta/elewa/assets/35740939/2e8d6b4f-5829-40b1-9a6f-2da3ef4dacbb)
