### PR TITLE
:lipstick: CLM-324 Align logo icon, hamburger and menu icons #789

### DIFF
--- a/libs/elements/layout/page-convl/src/lib/components/convl-sidemenu/convl-sidemenu.component.html
+++ b/libs/elements/layout/page-convl/src/lib/components/convl-sidemenu/convl-sidemenu.component.html
@@ -67,7 +67,7 @@
                   {{'PAGE-CONTENT.SIDE-MENU.MESSAGING'| transloco }}
                 </span>
               </a>
-              <ul class="sub-side-menu">
+              <ul [ngClass]="{ 'sub-side-menu': isExpanded, 'sub-side-menu-collapsed': !isExpanded }">
                 <li matTooltip="{{'PAGE-CONTENT.SIDE-MENU.CHATS'| transloco }}">
                   <a *hasViewAccess="CAN_ACCESS_CHATS" class="menu-item" routerLink="/chats" routerLinkActive="active">
                     <span class="menu-icon">

--- a/libs/elements/layout/page-convl/src/lib/components/convl-sidemenu/convl-sidemenu.component.scss
+++ b/libs/elements/layout/page-convl/src/lib/components/convl-sidemenu/convl-sidemenu.component.scss
@@ -632,6 +632,15 @@ a {
     margin-top: -10px;
   }
 }
+
+.sub-side-menu-collapsed{
+  padding-left: 0rem!important;
+  font-size: .85rem!important;
+  li{
+    margin-top: -10px;
+  }
+}
+
 .collapsible {
   display: none; 
 }


### PR DESCRIPTION
# Description

this pr aligns the hambuger and logo icon with other icons. aligned the message sub menu to one line since the width causes the center position of the hambuger and logo icon to change. 

Fixes #789

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# Screenshot (optional)

![Screenshot from 2023-11-01 10-56-10](https://github.com/italanta/elewa/assets/71401172/6c029f7a-6759-44c7-a1c7-71fd241288d4)
![Screenshot from 2023-11-01 10-55-56](https://github.com/italanta/elewa/assets/71401172/86b9a1da-640c-4241-aace-fae548b07dd4)



# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**: (optional)
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
