### PR TITLE
:recycle: CLM-323-Align-wording-and-menu-icons-#786

### DIFF
--- a/libs/elements/layout/page-convl/src/lib/components/convl-sidemenu/convl-sidemenu.component.scss
+++ b/libs/elements/layout/page-convl/src/lib/components/convl-sidemenu/convl-sidemenu.component.scss
@@ -216,25 +216,34 @@ $sidebar-footer-height: 230px;
         a {
           display: flex;
           align-items: center;
-          height: 35px;
+          height: 25px;
           padding: 0 20px;
           color: $text-color;
           margin-bottom: 20px;
           padding-left: 30px;
+          justify-content: center;
 
           .menu-icon {
             cursor: pointer;
             font-size: 1.2rem;
-            width: 35px;
-            min-width: 30px;
-            height: 30px;
+            width: 25px;
+            min-width: 20px;
+            height: 20px;
             line-height: 35px;
             text-align: center;
-            display: inline-block;
             margin-right: 10px;
             border-radius: 2px;
             transition: color 0.3s;
             cursor: pointer;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+
+            .img{
+              height: 100%;
+              width: 100%;
+            }
+
             i {
               display: inline-block;
             }
@@ -247,6 +256,7 @@ $sidebar-footer-height: 230px;
             white-space: nowrap;
             flex-grow: 1;
             transition: color 0.3s;
+            height: 20px;
           }
           .message-title{
             cursor: default !important;


### PR DESCRIPTION
# Description

- CLM-323-Align-wording-and-menu-icons

Fixes #786

# Screenshot (optional)
![Screenshot from 2023-11-01 12-57-25](https://github.com/italanta/elewa/assets/109853680/ed7b0563-63c4-430d-82d6-79cb88ac121c)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
