### PR TITLE
:lipstick: CLM-330-Change cursor from I-beam to hand when hovering over "send reminder" in surveys 

### DIFF
--- a/libs/features/convs-mgr/conversations/surveys/src/lib/pages/survey-responses/survey-responses.component.scss
+++ b/libs/features/convs-mgr/conversations/surveys/src/lib/pages/survey-responses/survey-responses.component.scss
@@ -73,4 +73,5 @@
     line-height: normal;
     text-decoration-line: underline;
     padding-left: 3.19rem;
+    cursor: pointer;
   }


### PR DESCRIPTION
# Description

Replaced the I-beam cursor of  "send reminder"  with a cursor pointer 

Fixes #819 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Screenshot 
![Screenshot from 2023-11-03 14-10-15](https://github.com/italanta/elewa/assets/117742892/8477368a-1862-4a70-ae7b-2746dce13e46)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

