### PR TITLE
:lipstick: Add thematic break

### DIFF
--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.html
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.html
@@ -30,7 +30,7 @@
             </button> 
         </div>
     
-        <hr class="form-border"> 
+        <hr> 
 
         <div *ngSwitchCase="messagetype">
             <app-message-block [id]="id" [block]="block" [jsPlumb]="jsPlumb" [textMessageForm]="blockFormGroup">

--- a/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.scss
+++ b/libs/features/convs-mgr/stories/blocks/library/main/src/lib/components/block/block.component.scss
@@ -64,8 +64,8 @@ mat-card {
 	padding: 0;
 }
 
-.form-border {
-	border-top: 0.5px solid #DADADA;
+hr {
+	border: 0.5px solid var(--convs-mgr-border-color);
 }
 
 .icon-with-text{

--- a/libs/features/convs-mgr/stories/blocks/library/question-message-block/src/lib/components/questions-block/questions-block.component.scss
+++ b/libs/features/convs-mgr/stories/blocks/library/question-message-block/src/lib/components/questions-block/questions-block.component.scss
@@ -47,7 +47,6 @@ textarea:focus-visible {
 }
 
 form{
-  border-top: 1px solid var(--convs-mgr-border-color);
   padding-top: 0.3125rem;
 }
 


### PR DESCRIPTION
# Description

This pull request introduces a horizontal line within the <mat-card> element. The new implementation is aimed at improving the visual representation of the block structure

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Screenshot (optional)
Before
![Screenshot from 2023-11-14 10-07-55](https://github.com/italanta/elewa/assets/117742892/efff1e38-d0b3-491b-8074-807887884ead)
Now
![Screenshot from 2023-11-14 10-41-18](https://github.com/italanta/elewa/assets/117742892/466c4c2b-ac5d-4845-95f2-6268e254b4d6)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

