### PR TITLE
:lipstick: Changed cursor to hand pointer when hovering over hamburger in menu

### DIFF
--- a/libs/elements/layout/page-convl/src/lib/components/convl-sidemenu/convl-sidemenu.component.scss
+++ b/libs/elements/layout/page-convl/src/lib/components/convl-sidemenu/convl-sidemenu.component.scss
@@ -718,3 +718,6 @@ a {
   padding: 10px;
 }
 
+.nav-toggle{
+  cursor: pointer;
+}


### PR DESCRIPTION
# Description

As a user when hovering over the hamburger menu the cursor is a hand pointer.

Fixes #818

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Screenshot (optional)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings

