### PR TITLE
:lipstick: Changed the cursor when hovering over the 'send reminder' in surveys …

### DIFF
--- a/libs/features/convs-mgr/conversations/surveys/src/lib/pages/survey-responses/survey-responses.component.scss
+++ b/libs/features/convs-mgr/conversations/surveys/src/lib/pages/survey-responses/survey-responses.component.scss
@@ -73,4 +73,5 @@
     line-height: normal;
     text-decoration-line: underline;
     padding-left: 3.19rem;
+    cursor: pointer;
   }


### PR DESCRIPTION
# Description

As a user, when hovering over 'send-reminder' in surveys the cursor is a hand pointer and not an I-beam as this is a clickable field.
Fixes #819 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

# Screenshot (optional)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
