### PR TITLE
🐛 Fixed Double Eyes on Edge password Input field #clm-341

### DIFF
--- a/libs/features/app/auth/login/src/lib/components/login/login.component.scss
+++ b/libs/features/app/auth/login/src/lib/components/login/login.component.scss
@@ -137,3 +137,7 @@ input {
 :host ::ng-deep .mat-mdc-form-field-input-control.mat-mdc-form-field-input-control {
   font-weight: 400;
 }
+//hide the default password-eye icon specific to edge browser
+::-ms-reveal {
+  display: none;
+}

--- a/libs/features/app/auth/login/src/lib/components/register/register.component.scss
+++ b/libs/features/app/auth/login/src/lib/components/register/register.component.scss
@@ -78,3 +78,7 @@ label {
 :host ::ng-deep .mat-mdc-form-field-input-control.mat-mdc-form-field-input-control {
   font-weight: 400;
 }
+//hide the default password-eye icon specific to edge browser
+::-ms-reveal {
+  display: none;
+}


### PR DESCRIPTION
# Description

Here i added an inbuilt style specific to edge to hide the password eye


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


# Screenshot (optional)

# How Has This Been Tested?



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

