### PR TITLE
:recycle: :bug: CLM-320 Allow deletion of variables from template body

### DIFF
--- a/libs/private/features/convs-mgr/message-templates/src/lib/components/message-template-form/message-template-form.component.html
+++ b/libs/private/features/convs-mgr/message-templates/src/lib/components/message-template-form/message-template-form.component.html
@@ -97,12 +97,17 @@
                             <p class="np">{{'MESSAGE-TEMPLATES.MESSAGE-TEMPLATE-FORM.MT-FORM.FORM-BODY.CONTENT.BODY.SAMPLES.NOTICE'| transloco }}</p>
                             <p class="pees">{{'MESSAGE-TEMPLATES.MESSAGE-TEMPLATE-FORM.MT-FORM.FORM-BODY.CONTENT.BODY.BODY'| transloco }}</p>
                             
-                            <h6 class="vars" *ngFor="let variable of newVariables">{{variable.placeholder}}: <span>{{variable.variable}}</span></h6>
-                              <div [formGroup] = "newVariableForm">
-                                  <input type="text" formControlName="newPlaceholder" placeholder="Variable Name" class="eveinputs">
+                            <h6 class="vars" *ngFor="let variable of newVariables; let i = index">
+                                <span>{{variable.placeholder}}:</span>
+                                <span>{{variable.variable}}</span>
+                                <span><button (click)="removeVariable(i)">delete</button></span>
+                            </h6>
+
+                            <div [formGroup] = "newVariableForm">
+                                <input type="text" formControlName="newPlaceholder" placeholder="Variable Name" class="eveinputs">
                                 <input type="text" formControlName="newVariable" placeholder="Placeholder" class="eveinputs">
                                 <button (click)="addVariable()" *ngIf="newVariableForm.get('newPlaceholder')?.value && newVariableForm.get('newVariable')?.value">Add Variable</button> 
-                                </div>
+                            </div>
                         </div>
                         </div>
                     <div class="form-group">

--- a/libs/private/features/convs-mgr/message-templates/src/lib/components/message-template-form/message-template-form.component.scss
+++ b/libs/private/features/convs-mgr/message-templates/src/lib/components/message-template-form/message-template-form.component.scss
@@ -210,10 +210,21 @@
     font-weight: 400;
     height: 1rem;
     margin: 1rem;
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    column-gap: 1rem;
+
+    button {
+      border: none;
+      outline: none;
+      padding: 0.3rem;
+      cursor: pointer;
+    }
+  
     span{
       color: #1F7A8C;
-    font-style: 300;
-  
+      font-style: 300;
     }
   }
 

--- a/libs/private/features/convs-mgr/message-templates/src/lib/components/message-template-form/message-template-form.component.ts
+++ b/libs/private/features/convs-mgr/message-templates/src/lib/components/message-template-form/message-template-form.component.ts
@@ -121,6 +121,7 @@ export class MessageTemplateFormComponent implements OnInit{
     const formBody = formContent.get('body') as FormGroup;
     const bodyControl = formBody.get('text') as FormControl;
     const updatedBody = `${bodyControl.value}{{${newPlaceholder}}}`;
+
     bodyControl.setValue(updatedBody);
 
     // Track new variables as strings
@@ -136,7 +137,7 @@ export class MessageTemplateFormComponent implements OnInit{
 
   removeVariable(index: number) {
     // Get the placeholder to be removed
-    const placeholder = this.newVariables[index];
+    const { placeholder } = this.newVariables[index];
 
     // Remove the variable from the body
     const formContent = this.templateForm.get('content') as FormGroup;
@@ -151,6 +152,7 @@ export class MessageTemplateFormComponent implements OnInit{
     // Remove the placeholder from the newVariables array
     this.newVariables.splice(index, 1);
   }
+
   updateReferencesFromBody(updatedBody: string) {
     const formContent = this.templateForm.get('content') as FormGroup;
     const formBody = formContent.get('body') as FormGroup;
@@ -173,7 +175,7 @@ export class MessageTemplateFormComponent implements OnInit{
       }
     }
   }
-    
+
   cancel() {
     this._route$$.navigate(['/messaging'])
   }


### PR DESCRIPTION
# Description

This PR fixes the message template variables deletion bug.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist:

- [x] My code follows the style guidelines of this project
