### PR TITLE
:zap: :lipstick: Restrict story blocks from overlapping

### DIFF
--- a/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/model/story-editor-frame.model.ts
@@ -226,36 +226,35 @@ export class StoryEditorFrame
    * Create a new block for the frame.
    * TODO: Move this to a factory later
    */
-  newBlock(type: StoryBlockTypes, coordinates?:Coordinate) {
-
-    let x, y;
-
-    const filteredBlocks = this._blocks.filter((block)=> block.id !== 'story-end-anchor');
-
-    this._newestBlock = filteredBlocks.length > 0 ? filteredBlocks[filteredBlocks.length-1] : null;
-
-    if(this._newestBlock) {
-      x = this._newestBlock.position.x + Math.floor(Math.random() * (200) + 20);
-      y = this._newestBlock.position.y - Math.floor(Math.random() * (50) + 5);
-    } else {
-      x = 200;
-      y = 50;
+  newBlock(type: StoryBlockTypes, coordinates?: Coordinate) {
+    const block = this._createBlock(type, coordinates);
+    this._blocks.push(block);
+    return this._injectBlockToFrame(block);
+  }
+  
+  //private method which creates a block
+  _createBlock(type: StoryBlockTypes, coordinates?: Coordinate): StoryBlock {
+    const blockSize = 200; //default block size
+    const verticalSpacing = 60;
+  
+    let maxBlock = 0;
+  
+    if (this._blocks.length > 0) {
+      //find the maximum y coordinates of the blocks that exist
+      maxBlock = Math.max(...this._blocks.map((block) => block.position.y + blockSize));
     }
-
-    const block = {
+  
+    return {
       id: `${this._getID()}`,
       type: type,
       message: '',
-      // TODO: Positioning in the middle + offset based on _cnt
-      // position: coordinates || { x: 200, y: 50 },
-      position: coordinates || { x: x, y: y},
+      position: coordinates || {
+        x: 200,
+        y: maxBlock + verticalSpacing, 
+      },
     } as StoryBlock;
-
-    this._blocks.push(block);
-     
-    return this._injectBlockToFrame(block);
   }
-
+  
   /**
    * Private method which draws the block on the frame.
    * @see {BlockInjectorService} - package @app/features/convs-mgr/stories/blocks/library


### PR DESCRIPTION
# Description
This PR addresses the fixing of the overlapping story blocks. 
Modified the newBlock method to set a fixed y coordinate for each block, preventing vertical overlapping.

Fixes #516 

## Type of change

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)


# Screenshot
before 

[Goomza.webm](https://github.com/italanta/elewa/assets/117742892/450336ed-be1b-48f4-af2e-f4857a0572a7)

after

[Goomza (1).webm](https://github.com/italanta/elewa/assets/117742892/e92f6930-d907-4533-85e9-c5a0a8ce9272)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

