### PR TITLE
:art: :lipstick: Add ability to filter learners by classroom

### DIFF
--- a/libs/features/convs-mgr/learners/src/lib/pages/learners-page/learners-page.component.html
+++ b/libs/features/convs-mgr/learners/src/lib/pages/learners-page/learners-page.component.html
@@ -31,7 +31,7 @@
             <select [(value)]="selectedClass" (change)="filterTable($event,'class')">
               <option [value]="null" selected>{{ 'All Classes' | titlecase  }}</option>
 
-              <option *ngFor="let class of allClasses" [value]="class">{{ class.className | titlecase }}</option>
+              <option *ngFor="let class of allClasses" [value]="class.id">{{ class.className | titlecase }}</option>
             </select>
           </div>
 

--- a/libs/features/convs-mgr/learners/src/lib/pages/learners-page/learners-page.component.ts
+++ b/libs/features/convs-mgr/learners/src/lib/pages/learners-page/learners-page.component.ts
@@ -90,6 +90,22 @@ export class LearnersPageComponent implements OnInit, OnDestroy {
     this.getAllCourses();
     this.getAllPlatforms();
     this.getScheduleOptions();
+
+    this.dataSource.filterPredicate = function (enrolledEndUsers:EnrolledEndUser,filter:string) {
+      //return true if filter is undefined, null or empty string
+      if (filter === "undefined" || filter === "null" || filter === "") {
+        return true;
+      }
+      
+      // Check if the enrolledEndUsers's id matches the filter
+      const isMatch = enrolledEndUsers.classId === filter;
+
+      // Return true if there is a match, false otherwise
+      return isMatch;
+    }
+
+    
+    
   }
 
   getLearners() {
@@ -149,9 +165,10 @@ export class LearnersPageComponent implements OnInit, OnDestroy {
   }
 
   filterTable(event: Event, mode:string) {
+    const selectedClassValueId = (event.target as HTMLSelectElement).value;
     switch (mode) {
       case 'class':
-        this.dataSource.filter = this.selectedClass.ClassName;
+        this.dataSource.filter = selectedClassValueId;
         break
     }
   }


### PR DESCRIPTION
# Description

this pr Adds the ability to filter learners by selected classroom and displays all if no filter is passed.

Reference the issue related to this PR as shown below. Every issue has it's own number you can find the issue numbers [here](https://github.com/italanta/italanta-apps/issues).

Fixes #862 

## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)

# Screenshot (optional)

[Screencast from 02-12-2023 07:19:15 ALASIRI.webm](https://github.com/italanta/elewa/assets/71401172/1097318a-a310-441b-97bd-c4d406103688)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**: (optional)
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
