### PR TITLE
:lipstick: :recycle: Assessment and analytics insights pages design cleanup

### DIFF
--- a/apps/conv-learning-manager/src/assets/flags/featureFlags.json
+++ b/apps/conv-learning-manager/src/assets/flags/featureFlags.json
@@ -1,4 +1,4 @@
 {
     "surveys": false,
-    "analytics": false
+    "analytics": true
 }

--- a/apps/conv-learning-manager/src/assets/flags/featureFlags.json
+++ b/apps/conv-learning-manager/src/assets/flags/featureFlags.json
@@ -1,4 +1,4 @@
 {
     "surveys": false,
-    "analytics": true
+    "analytics": false
 }

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.scss
@@ -67,6 +67,7 @@
 		outline: none;
 		font-size: 15px;
 		padding-left: 6px;
+		font-weight: 300;
 	}
 }
 

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.scss
@@ -46,7 +46,7 @@
 .search {
 	height: 5px;
 	width: 97%;
-	background-color: var(--convs-mgr-color-primary-white);
+	background-color: inherit;
 	border-radius: 8px;
 	display: flex;
 	align-items: center;
@@ -62,6 +62,7 @@
 
 	&_input {
 		width: 90%;
+		background-color: inherit;
 		height: 30px;
 		border: none;
 		outline: none;

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.scss
@@ -55,7 +55,6 @@
 
 	&_tooltip {
 		color: gray;
-		transform: rotate(90deg);
 		font-size: 20px;
 		font-weight: 500;
 	}

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-header/assessments-header.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-header/assessments-header.component.scss
@@ -30,6 +30,7 @@
   color: #101010;
   font-size: 2rem;
   font-weight: 400;
+  margin-top: 10px;
 }
 
 .bottom-left {

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-header/assessments-header.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-header/assessments-header.component.scss
@@ -30,7 +30,7 @@
   color: #101010;
   font-size: 2rem;
   font-weight: 400;
-  margin-top: 10px;
+  margin-top: -10px;
 }
 
 .bottom-left {

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-header/assessments-header.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-header/assessments-header.component.scss
@@ -30,7 +30,7 @@
   color: #101010;
   font-size: 2rem;
   font-weight: 400;
-  margin-top: -10px;
+  margin-top: -0.625em;
 }
 
 .bottom-left {

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-list-view/assessments-list-view.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-list-view/assessments-list-view.component.scss
@@ -19,7 +19,7 @@
 
 .badge {
   display: inline-block;
-  padding: 0.25em 0.4em;
+  padding: 0.625em;
   font-size: .9em;
   font-weight: 400;
   line-height: 1;
@@ -33,6 +33,6 @@
 
   &.active {
     background-color: #3E788A;
-    padding:10px;
+    padding:0.625em;
   }
 }

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-list-view/assessments-list-view.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-list-view/assessments-list-view.component.scss
@@ -29,7 +29,7 @@
   border-radius: 0.25rem;
   color: black;
   background-color: #DAE0F0;
-  width: 1em;
+  width: 4.5em;
 
   &.active {
     background-color: #3E788A;

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-list-view/assessments-list-view.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-list-view/assessments-list-view.component.scss
@@ -27,7 +27,7 @@
   white-space: nowrap;
   vertical-align: baseline;
   border-radius: 0.25rem;
-  color: black;
+  color: var(--convs-mgr-color-text-white);
   background-color: #DAE0F0;
   width: 4.5em;
 

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-list-view/assessments-list-view.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-list-view/assessments-list-view.component.scss
@@ -12,7 +12,8 @@
 }
 
 .mat-mdc-row:hover .mat-mdc-cell {
-	background-color: #eee;
+	background-color: #1F7A8C;
+  opacity: 40%;
 	cursor: pointer;
 }
 

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-list-view/assessments-list-view.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-list-view/assessments-list-view.component.scss
@@ -29,6 +29,7 @@
   border-radius: 0.25rem;
   color: black;
   background-color: #DAE0F0;
+  width: 1em;
 
   &.active {
     background-color: #3E788A;

--- a/libs/private/features/convs-mgr/analytics/src/lib/pages/dashboard-page/dashboard-page.component.scss
+++ b/libs/private/features/convs-mgr/analytics/src/lib/pages/dashboard-page/dashboard-page.component.scss
@@ -7,8 +7,9 @@
   padding: 30px 50px;
 
   .title {
-    font-size: 3rem;
+    font-size: 2rem;
     font-weight: 400;
+    margin-top: -0.625em;
     text-transform: capitalize;
   }
 

--- a/libs/private/features/convs-mgr/analytics/src/lib/pages/dashboard-page/dashboard-page.component.scss
+++ b/libs/private/features/convs-mgr/analytics/src/lib/pages/dashboard-page/dashboard-page.component.scss
@@ -23,6 +23,7 @@
     .items {
       display: flex;
       gap: 0.5rem;
+      margin-bottom: 2em;
 
       .item_btn {
         display: flex;


### PR DESCRIPTION
# Description

this pr redesigns the assessments page

Reference the issue related to this PR as shown below. Every issue has it's own number you can find the issue numbers [here](https://github.com/italanta/italanta-apps/issues).

Fixes #887

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Screenshot (optional)

![Screenshot from 2023-12-07 12-23-25](https://github.com/italanta/elewa/assets/71401172/415e67ee-ee62-4fdd-8880-6a213b9b566b)

![Screenshot from 2023-12-07 12-36-26](https://github.com/italanta/elewa/assets/71401172/4c7c7589-886e-4037-bb07-4859f0c309dd)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**: (optional)
* Firmware version:
* Hardware:
* Toolchain:
* SDK:

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
