### PR TITLE
:lipstick: feat: Assessment and analytics/insights pages design cleanup #887

### DIFF
--- a/apps/conv-learning-manager/src/assets/flags/featureFlags.json
+++ b/apps/conv-learning-manager/src/assets/flags/featureFlags.json
@@ -1,4 +1,4 @@
 {
     "surveys": false,
-    "analytics": false
+    "analytics": true
 }

--- a/apps/conv-learning-manager/src/assets/flags/featureFlags.json
+++ b/apps/conv-learning-manager/src/assets/flags/featureFlags.json
@@ -1,4 +1,4 @@
 {
     "surveys": false,
-    "analytics": true
+    "analytics": false
 }

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.scss
@@ -67,6 +67,7 @@
 		outline: none;
 		font-size: 15px;
 		padding-left: 6px;
+		background-color: var(--convs-mgr-color-primary-white);
 	}
 }
 

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.scss
@@ -68,6 +68,7 @@
 		font-size: 15px;
 		padding-left: 6px;
 		background-color: var(--convs-mgr-color-primary-white);
+		font-weight: 300;
 	}
 }
 

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-list/assessment-list.component.scss
@@ -55,7 +55,7 @@
 
 	&_tooltip {
 		color: gray;
-		transform: rotate(90deg);
+		transform: rotate(360deg);
 		font-size: 20px;
 		font-weight: 500;
 	}

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-header/assessments-header.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-header/assessments-header.component.scss
@@ -30,6 +30,7 @@
   color: #101010;
   font-size: 2rem;
   font-weight: 400;
+  margin-top: -10px;
 }
 
 .bottom-left {

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-list-view/assessments-list-view.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-list-view/assessments-list-view.component.scss
@@ -35,5 +35,6 @@
   &.active {
     background-color: #3E788A;
     padding:10px;
+    color: #FFFFFF;
   }
 }

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-list-view/assessments-list-view.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-list-view/assessments-list-view.component.scss
@@ -9,11 +9,13 @@
 	font-size: 1rem;
 	font-weight: 400;
 	border-bottom: 1px solid rgba($color: #707070, $alpha: 0.25);
+  transition: background-color 0.3s ease;
 }
 
 .mat-mdc-row:hover .mat-mdc-cell {
-	background-color: #eee;
+	background-color: #1F7A8C;
 	cursor: pointer;
+  opacity: 40%;
 }
 
 .badge {

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-list-view/assessments-list-view.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessments-list-view/assessments-list-view.component.scss
@@ -20,7 +20,7 @@
 
 .badge {
   display: inline-block;
-  padding: 0.25em 0.4em;
+  padding: 0.625em;
   font-size: .9em;
   font-weight: 400;
   line-height: 1;
@@ -30,6 +30,7 @@
   border-radius: 0.25rem;
   color: black;
   background-color: #DAE0F0;
+  width: 70px;
 
   &.active {
     background-color: #3E788A;

--- a/libs/private/features/convs-mgr/analytics/src/lib/pages/dashboard-page/dashboard-page.component.scss
+++ b/libs/private/features/convs-mgr/analytics/src/lib/pages/dashboard-page/dashboard-page.component.scss
@@ -7,9 +7,10 @@
   padding: 30px 50px;
 
   .title {
-    font-size: 3rem;
+    font-size: 2rem;
     font-weight: 400;
     text-transform: capitalize;
+    margin-top: -10px;
   }
 
   .menu-items {

--- a/libs/private/features/convs-mgr/analytics/src/lib/pages/dashboard-page/dashboard-page.component.scss
+++ b/libs/private/features/convs-mgr/analytics/src/lib/pages/dashboard-page/dashboard-page.component.scss
@@ -19,6 +19,7 @@
     align-items: center;
     gap: 10px;
     width: 100%;
+    margin-bottom: 0.625em;
 
     .items {
       display: flex;


### PR DESCRIPTION
# Description

**Assessments**

1. Assessments Page Title
- Set page title font-size to 2rem, font-weight to 400, and margin-top to -10px.

2. Search Function
- Removed the white background from the search input field.
- Adjusted the search icon to face the opposite direction.
- Lightened the font-weight of 'Search for a Course' (font-weight: 300).

3. Table Row Hover Effect

- Implemented a hover effect on table data with background-color: #1F7A8C and 40% opacity.

4. Status row on assessments table
- Designed Different status to have the same width.
- Changed the published status to have font-color: #FFFFFF

**Insights/Analytics**

- Designed Analytics page title to have font-size: 2rem, font-weight: 400, margin-top: -10px.
- Increased the margin between the filters and the analytics cards.

Fixes #887

## Assessment and analytics/insights pages design cleanup

- [x] New feature (non-breaking change which adds functionality)

# Screenshot (optional)
![screen shot 1](https://github.com/italanta/elewa/assets/109853680/9742d51a-502b-4d13-9ff9-f01b27628052)
![screen shot 2](https://github.com/italanta/elewa/assets/109853680/2fcb718e-bbb5-4d62-9375-53bc842bf5e7)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
