### PR TITLE
💄 CLM-381 Disable messaging menu tooltip when menu is expanded

### DIFF
--- a/libs/elements/layout/page-convl/src/lib/components/convl-sidemenu/convl-sidemenu.component.html
+++ b/libs/elements/layout/page-convl/src/lib/components/convl-sidemenu/convl-sidemenu.component.html
@@ -61,7 +61,7 @@
 
             <!-- Messaging sections -->
             <li class="menu-item" (click)="toggleDropdown()">
-              <a matTooltipPosition="above" matTooltip="{{'PAGE-CONTENT.SIDE-MENU.MESSAGING'| transloco }}">
+              <a matTooltipPosition="above" matTooltip="{{'PAGE-CONTENT.SIDE-MENU.MESSAGING'| transloco }}" [matTooltipDisabled]="isDropdownOpen">
                 <span class="menu-icon">
                   <img *ngIf="isExpanded" src="assets/icons/chats-stroked.svg" class="img" alt="">
                   <img *ngIf="!isExpanded"  src="assets/icons/chats-stroked.svg" class="img" alt="">


### PR DESCRIPTION
# Description

Disable messaging menu tooltip when menu is expanded 