### PR TITLE
💄Removed settings button on the assessment page #CLM-354

### DIFF
--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/create-assessment-flow/create-assessment-page/create-assessment-page.component.html
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/create-assessment-flow/create-assessment-page/create-assessment-page.component.html
@@ -22,9 +22,6 @@
           <app-assessment-question-forms [previewMode]="false" [questions]="questions" [assessmentFormGroup]="assessmentFormModel.assessmentsFormGroup">
           </app-assessment-question-forms>
         </mat-tab>
-        <mat-tab label="Settings">
-          <app-assessment-config [previewMode]="false" [assessmentFormGroup]="assessmentFormModel.assessmentsFormGroup"></app-assessment-config>
-        </mat-tab>
         <mat-tab label="Preview">
           <!-- use the view component to create the form preview -->
           <app-assessment-view [assessmentForm]="assessmentFormModel.assessmentsFormGroup"></app-assessment-view>

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/create-assessment-flow/create-assessment-page/create-assessment-page.component.html
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/create-assessment-flow/create-assessment-page/create-assessment-page.component.html
@@ -22,6 +22,10 @@
           <app-assessment-question-forms [previewMode]="false" [questions]="questions" [assessmentFormGroup]="assessmentFormModel.assessmentsFormGroup">
           </app-assessment-question-forms>
         </mat-tab>
+        <!-- Temporarily removed the settings button since there is no feedback option as of now -->
+        <!-- <mat-tab label="Settings">
+          <app-assessment-config [previewMode]="false" [assessmentFormGroup]="assessmentFormModel.assessmentsFormGroup"></app-assessment-config>
+        </mat-tab> -->
         <mat-tab label="Preview">
           <!-- use the view component to create the form preview -->
           <app-assessment-view [assessmentForm]="assessmentFormModel.assessmentsFormGroup"></app-assessment-view>


### PR DESCRIPTION
# Description
Removed the settings button on the assessment page since there is no feedback option

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes