### PR TITLE
:wrench: :lipstick: CLM-213 Disable selection of past dates 

### DIFF
--- a/libs/private/features/convs-mgr/message-templates/src/lib/modals/specific-time-modal/specific-time-modal.component.html
+++ b/libs/private/features/convs-mgr/message-templates/src/lib/modals/specific-time-modal/specific-time-modal.component.html
@@ -14,7 +14,7 @@
       <div class="date">
         <mat-form-field appearance="outline">
           <div class="date-input">
-            <input matInput  [matDatepicker]="startDatePicker" id="startDate" [placeholder]="Date"  name="date"  formControlName="date">
+            <input matInput  [matDatepicker]="startDatePicker" id="startDate" [placeholder]="Date" [min]="todaysDate"  name="date"  formControlName="date">
             <mat-datepicker-toggle matIconSuffix [for]="startDatePicker"></mat-datepicker-toggle>
           </div>
           <mat-datepicker #startDatePicker></mat-datepicker>

--- a/libs/private/features/convs-mgr/message-templates/src/lib/modals/specific-time-modal/specific-time-modal.component.ts
+++ b/libs/private/features/convs-mgr/message-templates/src/lib/modals/specific-time-modal/specific-time-modal.component.ts
@@ -34,25 +34,26 @@ export class SpecificTimeModalComponent {
   menuButtonText = 'Never';
   cronFormat: string; 
 
+  todaysDate = new Date();
 
-    // Arrays to populate the "Repeat every" select dropdowns
-    dailyOptions: number[] = Array.from({ length: 30 }, (_, i) => i + 1);
-    weeklyOptions: number[] = Array.from({ length: 20 }, (_, i) => i + 1);
-    monthlyOptions: number[] = Array.from({ length: 31 }, (_, i) => i + 1);
+  // Arrays to populate the "Repeat every" select dropdowns
+  dailyOptions: number[] = Array.from({ length: 30 }, (_, i) => i + 1);
+  weeklyOptions: number[] = Array.from({ length: 20 }, (_, i) => i + 1);
+  monthlyOptions: number[] = Array.from({ length: 31 }, (_, i) => i + 1);
 
-    // Add the weekdays array to your component
-    weekdays = weekdays;
+  // Add the weekdays array to your component
+  weekdays = weekdays;
 
-     // Define an array of radio option values
-    recurrenceOptions = recurrenceOptions;
+    // Define an array of radio option values
+  recurrenceOptions = recurrenceOptions;
 
-  
-    // Properties for selected repeat values
-    selectedDailyRepeat: number;
-    selectedWeeklyRepeat: number;
-    selectedMonthlyRepeat: number;
-    Date = "Date";
-    Time = "Date";
+
+  // Properties for selected repeat values
+  selectedDailyRepeat: number;
+  selectedWeeklyRepeat: number;
+  selectedMonthlyRepeat: number;
+  Date = "Date";
+  Time = "Date";
 
   constructor(
     private dialogRef: MatDialogRef<SpecificTimeModalComponent>, 


### PR DESCRIPTION
# Description

Prevents users from selecting the past dates when scheduling a message template.