### PR TITLE
🐛 Fix Option issues

### DIFF
--- a/libs/features/convs-mgr/stories/blocks/library/block-options/src/lib/providers/jsplumb-decorator.function.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/block-options/src/lib/providers/jsplumb-decorator.function.ts
@@ -11,6 +11,14 @@ import { FlowchartConnector } from "@jsplumb/connector-flowchart";
 
 export function _JsPlumbInputOptionDecorator(sourceElement: Element, jsPlumb: BrowserJsPlumbInstance): Element
 {
+  // Clear all endpoints attached to the source element before reattaching an endpoint
+  //  Without this, jsPlumb does not calculate the position of an endpoint properly after deleting
+  //   an element(an option), hence when you readd an option it will not have an endpoint until 
+  //    the page is refreshed.
+
+  // Fixes #CLM-405 - Sometimes when adding options, no connector point is linked to new option
+  jsPlumb.removeAllEndpoints(sourceElement);
+
   jsPlumb.addEndpoint(sourceElement, {
     source: true,
     // Type of endpoint to render

--- a/libs/features/convs-mgr/stories/blocks/library/question-message-block/src/lib/components/questions-block/questions-block.component.ts
+++ b/libs/features/convs-mgr/stories/blocks/library/question-message-block/src/lib/components/questions-block/questions-block.component.ts
@@ -65,10 +65,15 @@ export class QuestionsBlockComponent implements OnInit
   }
 
   deleteInput(i: number) {
+    const optionElementId = `i-${i}-${this.id}`;
+
+    const optionElement = document.getElementById(optionElementId) as Element;
+    
+    this.jsPlumb.removeAllEndpoints(optionElement);
+    
+    this.jsPlumb.deleteConnectionsForElement(optionElement)
+    
     this.options.removeAt(i);
-    // TODO: Wrapper around jsPlumb instance that can take care of such operations more cleanly
-    const conns = this.jsPlumb.connections.filter((c) => c.sourceId === `i-${i}-${this.id}`);
-    conns.forEach(c => this.jsPlumb.deleteConnection(c));
   }
 
   setFocusOnNextInput() {

--- a/libs/features/convs-mgr/stories/editor/src/lib/providers/save-story.service.ts
+++ b/libs/features/convs-mgr/stories/editor/src/lib/providers/save-story.service.ts
@@ -54,14 +54,13 @@ export class SaveStoryService
   {
     const connsToProcess = [];
     const connsPlumb = frame.jsPlumbInstance.connections;
-
     for(const c of connsPlumb)
     {
       // Get target block from target ID or target.id param on the connection
       const target = state.blocks.find(b => b.id === c.target.id) ?? state.blocks.find(b => b.id === c.targetId);
       
       if(target)
-        connsToProcess.push(({ id: c.id, sourceId: c.sourceId, targetId: target.id }) as StoryBlockConnection);
+        connsToProcess.push(({ id: c.id, sourceId: c.source.id, targetId: target.id }) as StoryBlockConnection);
       else 
         this.validator.push({ 
           type: StoryErrorType.MissingConnection,


### PR DESCRIPTION
# Description

This PR fixes CLM-405 and CLM-398.

CLM-405 - Removing all endpoints from an element before adding the endpoint solves the issue of the endpoint not appearing next to the option sometimes when added.

CLM-398 - When getting connections from frame, we used to use `jsplumb.Connection.sourceId` which is inconsistent and does not necesarily refer to the element we are connecting to. This has been changed to `jsplumb.Connection.source.id` which is more consistent because it contains our actual html element