### PR TITLE
🎮 🤖 CLM-33 Implement backend to support Web preview of Bot

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -898,6 +898,29 @@
       },
       "tags": []
     },
+    "functions-bot-engine-preview": {
+      "root": "libs/functions/bot-engine/preview",
+      "sourceRoot": "libs/functions/bot-engine/preview/src",
+      "projectType": "library",
+      "targets": {
+        "lint": {
+          "executor": "@nrwl/linter:eslint",
+          "outputs": ["{options.outputFile}"],
+          "options": {
+            "lintFilePatterns": ["libs/functions/bot-engine/preview/**/*.ts"]
+          }
+        },
+        "test": {
+          "executor": "@nrwl/jest:jest",
+          "outputs": ["coverage/libs/functions/bot-engine/preview"],
+          "options": {
+            "jestConfig": "libs/functions/bot-engine/preview/jest.config.ts",
+            "passWithNoTests": true
+          }
+        }
+      },
+      "tags": []
+    },
     "functions-bot-engine-send-message": {
       "root": "libs/functions/bot-engine/send-message",
       "sourceRoot": "libs/functions/bot-engine/send-message/src",

--- a/apps/conv-lm-backend/src/app/bot/preview-channel/preview-channel.function.ts
+++ b/apps/conv-lm-backend/src/app/bot/preview-channel/preview-channel.function.ts
@@ -1,0 +1,24 @@
+import { RestRegistrar } from "@ngfi/functions";
+
+import { PreviewChannelReceiveHandler } from "@app/functions/bot-engine/preview";
+
+import { ConvLearnFunction } from "../../../conv-learn-func.class";
+
+
+const handler = new PreviewChannelReceiveHandler();
+
+/**
+ * @Description : When an end user sends a message to the chatbot, this function is triggered, 
+ *      handles the message and potentially responds to it
+ * 
+ * It is specifically for Whatsapp @see {PlatformType}, and subscribes to the 'messages' webhook on
+ *      the Meta Developers platform
+ * 
+ * @see https://developers.facebook.com/docs/whatsapp/cloud-api/guides/set-up-webhooks
+ * 
+ */
+export const previewChannelReceiveIncmngMsg = new ConvLearnFunction('previewChannelReceiveIncmngMsg', 
+                                                  new RestRegistrar('asia-south1'), 
+                                                  [], 
+                                                  handler) 
+                               .build();

--- a/apps/conv-lm-backend/src/main.ts
+++ b/apps/conv-lm-backend/src/main.ts
@@ -23,6 +23,8 @@ export * from './app/bot/main/schedule/check-inactivity.function';
 export * from './app/bot/main/schedule/set-inactivity.function';
 export * from './app/bot/main/schedule/run-schedule.function';
 
+export * from './app/bot/preview-channel/preview-channel.function';
+
 export * from './app/micro-apps/cmi5/fetch-token.function';
 export * from './app/micro-apps/cmi5/cmi5-zip-parser.function';
 export * from './app/micro-apps/cmi5/cmi-listener.function';

--- a/libs/functions/bot-engine/main/src/lib/engine-bot-manager.handler.ts
+++ b/libs/functions/bot-engine/main/src/lib/engine-bot-manager.handler.ts
@@ -87,12 +87,12 @@ export class EngineBotManager
 
       const connDataService = new ConnectionsDataService(this._activeChannel.channel, this._tools);
       const blockDataService = new BlockDataService(this._activeChannel.channel, connDataService, this._tools);
-      const cursorDataService = new CursorDataService(this._tools);
-      const _msgDataService$ = new MessagesDataService(this._tools);
+      const cursorDataService = new CursorDataService(this._tools, this.previewMode);
+      const _msgDataService$ = new MessagesDataService(this._tools, this.previewMode);
   
-      this._endUserService$ = new EndUserDataService(this._tools, this.orgId);
+      this._endUserService$ = new EndUserDataService(this._tools, this.orgId, this.previewMode);
       const enrolledUserService = new EnrolledUserDataService(this._tools, this.orgId);
-      const processMessageService = new ProcessMessageService(cursorDataService, connDataService, blockDataService, this._tools, this._activeChannel, processMediaService, this.isPreviewMode);
+      const processMessageService = new ProcessMessageService(cursorDataService, connDataService, blockDataService, this._tools, this._activeChannel, processMediaService, this.previewMode);
 
       const END_USER_ID = endUser.id;
 
@@ -197,11 +197,11 @@ export class EngineBotManager
   }
 
   getPreviewMode() {
-    return this.isPreviewMode;
+    return this.previewMode;
   }
 
   setPreviewMode(preview: boolean) {
-    this.isPreviewMode = preview;
-    return this.isPreviewMode;
+    this.previewMode = preview;
+    return this.previewMode;
   }
 }

--- a/libs/functions/bot-engine/main/src/lib/model/active-channel.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/model/active-channel.service.ts
@@ -25,9 +25,9 @@ export interface ActiveChannel
    * @returns {Message}
    * A prepared  message which can be sent over the line to its specific channel API.
    */
-  parseOutMessage(storyBlock: StoryBlock, endUser: EndUser): OutgoingMessagePayload;
+  parseOutMessage: (storyBlock: StoryBlock, endUser: EndUser) => OutgoingMessagePayload;
 
-  parseOutStandardMessage(message: Message): any;
+  parseOutStandardMessage?: (message: Message) => any;
 
   /** 
    *  After the bot engine processes the incoming message and returns the next block,
@@ -41,9 +41,9 @@ export interface ActiveChannel
    *                      with the chatbot
    * 
    */
-  send(msg: OutgoingMessagePayload, standardMessage?: Message);
+  send: (msg: OutgoingMessagePayload, standardMessage?: Message) => any;
 
-  getMediaFile(mediaId: string, mime_type: string);
+  getMediaFile?: (mediaId: string, mime_type: string) => Promise<unknown>;
 
-  parseOutMessageTemplate(templateConfig: MessageTemplateConfig, params: TemplateMessageParams[], phoneNumber: string, message: Message);
+  parseOutMessageTemplate?: (templateConfig: MessageTemplateConfig, params: TemplateMessageParams[], phoneNumber: string, message: Message) => any;
 }

--- a/libs/functions/bot-engine/main/src/lib/services/data-services/cursor.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/data-services/cursor.service.ts
@@ -18,7 +18,7 @@ export class CursorDataService extends BotDataService<Cursor> {
   private tools: HandlerTools;
   private _currentCursor: Cursor;
 
-  constructor(_tools: HandlerTools) 
+  constructor(_tools: HandlerTools, private isPreview?: boolean) 
   {
     super(_tools);
     this.tools = _tools;
@@ -33,7 +33,7 @@ export class CursorDataService extends BotDataService<Cursor> {
   async getLatestCursor(endUserId: string, orgId: string): Promise<Cursor | boolean>
   {
     // Set the firestore document path
-    this._docPath = `orgs/${orgId}/end-users/${endUserId}/cursor`;
+    this._docPath = this._getDocPath(orgId, endUserId);
 
     // Get the latest document which is the latest cursor = the current position of the end user
     const currentCursor = await this.getLatestDocument(this._docPath);
@@ -59,7 +59,7 @@ export class CursorDataService extends BotDataService<Cursor> {
    */
   async getUserCursorAtSetTime(unixToMeasure: number, orgId:string, endUserId: string) : Promise<{ time: Date, cursor: Cursor }>
   {
-    this._docPath = `orgs/${orgId}/end-users/${endUserId}/cursor`;
+    this._docPath = this._getDocPath(orgId, endUserId);
   
     // Convert unix time to date
     const timeToMeasure = new Date(unixToMeasure);
@@ -87,7 +87,7 @@ export class CursorDataService extends BotDataService<Cursor> {
     const cursorId = Date.now().toString();
 
     // Set the document path of the cursor collection
-    this._docPath = `orgs/${orgId}/end-users/${endUserId}/cursor`;
+    this._docPath = this._getDocPath(orgId, endUserId);
 
     try {
       await this.createDocument(newCursor, this._docPath, cursorId);
@@ -100,5 +100,15 @@ export class CursorDataService extends BotDataService<Cursor> {
 
       return false;
     }
+  }
+
+  private _getDocPath(orgId: string, endUserId: string) {
+    this._docPath = `orgs/${orgId}/end-users/${endUserId}/cursor`;
+
+    if(this.isPreview) {
+      this._docPath = `orgs/${orgId}/preview-channels/${endUserId}_${orgId}/cursor`;
+    }
+
+    return this._docPath;
   }
 }

--- a/libs/functions/bot-engine/main/src/lib/services/data-services/end-user.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/data-services/end-user.service.ts
@@ -11,7 +11,7 @@ import { ChatStatus, EndUser } from '@app/model/convs-mgr/conversations/chats';
   private _docPath: string;
   tools: HandlerTools;
 
-  constructor(tools: HandlerTools, orgId: string) 
+  constructor(tools: HandlerTools, orgId: string, private isPreview?: boolean) 
   {
     super(tools);
     this.tools = tools;
@@ -20,7 +20,7 @@ import { ChatStatus, EndUser } from '@app/model/convs-mgr/conversations/chats';
 
   protected _init(orgId: string): void 
   {
-    this._docPath = `orgs/${orgId}/end-users`;
+    this._docPath = this._getDocPath(orgId);
   }
 
   async createEndUser(endUser: EndUser, enrolledUserID: string)
@@ -82,5 +82,15 @@ import { ChatStatus, EndUser } from '@app/model/convs-mgr/conversations/chats';
 
       return this.updateDocument(newEndUser, this._docPath, endUser.id);
     }
+  }
+
+  private _getDocPath(orgId: string) {
+    this._docPath = `orgs/${orgId}/end-users`;
+
+    if(this.isPreview) {
+      this._docPath = `orgs/${orgId}/preview-channels`;
+    }
+
+    return this._docPath;
   }
 }

--- a/libs/functions/bot-engine/main/src/lib/services/data-services/messages.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/data-services/messages.service.ts
@@ -12,7 +12,7 @@ export class MessagesDataService extends BotDataService<Message> {
   private _msg: Message;
   tools: HandlerTools;
 
-  constructor(tools: HandlerTools) 
+  constructor(tools: HandlerTools, private isPreview?: boolean) 
   {
     super(tools)
     this.tools = tools;
@@ -24,7 +24,7 @@ export class MessagesDataService extends BotDataService<Message> {
    * Assigns an id to the message if it is not yet set before this point
    */
   async saveMessage(msg: Message, orgId: string, endUserId: string): Promise<Message> {
-    this._docPath = `orgs/${orgId}/end-users/${endUserId}/messages`
+    this._docPath = this._getDocPath(orgId, endUserId);
 
     // If the message id is not set, we set it here
     !msg.id && (msg.id = Date.now().toString());
@@ -38,7 +38,7 @@ export class MessagesDataService extends BotDataService<Message> {
   }
 
   async getLatestMessage(endUserId: string, orgId: string): Promise<Message> {
-    this._docPath = `orgs/${orgId}/end-users/${endUserId}/messages`
+    this._docPath = this._getDocPath(orgId, endUserId);
 
     const latestMessage = await this.getLatestDocument(this._docPath);
 
@@ -46,7 +46,7 @@ export class MessagesDataService extends BotDataService<Message> {
   }
 
   async getLatestUserMessage(endUserId: string, orgId: string): Promise<Message> {
-    this._docPath = `orgs/${orgId}/end-users/${endUserId}/messages`
+    this._docPath = this._getDocPath(orgId, endUserId);
 
     const latestMessage = await this.getDocuments(this._docPath);
 
@@ -61,5 +61,15 @@ export class MessagesDataService extends BotDataService<Message> {
     });
 
     return latestUserMessage;
+  }
+
+  private _getDocPath(orgId: string, endUserId: string) {
+    this._docPath = `orgs/${orgId}/end-users/${endUserId}/messages`;
+
+    if(this.isPreview) {
+      this._docPath = `orgs/${orgId}/preview-channels/${endUserId}_${orgId}/messages`;
+    }
+
+    return this._docPath;
   }
 }

--- a/libs/functions/bot-engine/main/src/lib/services/data-services/variables.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/data-services/variables.service.ts
@@ -13,7 +13,7 @@ export class VariablesDataService extends BotDataService<any>{
   tools: HandlerTools;
   endUserId: string;
 
-  constructor(tools: HandlerTools, orgId: string, endUserId: string, private _commChannel: CommunicationChannel) 
+  constructor(tools: HandlerTools, orgId: string, endUserId: string, private _commChannel: CommunicationChannel, private isPreview?: boolean) 
   {
     super(tools);
     this.tools = tools;
@@ -22,7 +22,7 @@ export class VariablesDataService extends BotDataService<any>{
 
   protected _init(orgId: string, endUserId:string): void 
   {
-    this._docPath = `orgs/${orgId}/end-users`;
+    this._docPath = this._getDocPath(orgId);
 
     this.endUserId = endUserId;
   }
@@ -57,5 +57,15 @@ export class VariablesDataService extends BotDataService<any>{
     if(!allVariables) return '';
 
     return allVariables[variable];
+  }
+
+  private _getDocPath(orgId: string) {
+    this._docPath = `orgs/${orgId}/end-users`;
+
+    if(this.isPreview) {
+      this._docPath = `orgs/${orgId}/preview-channels`;
+    }
+
+    return this._docPath;
   }
 }

--- a/libs/functions/bot-engine/main/src/lib/services/media/process-media-service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/media/process-media-service.ts
@@ -54,7 +54,7 @@ export class BotMediaProcessService
   async getFileURL(message: FileMessage, endUserId: string, activeChannel: ActiveChannel)
   {
     if(!this.mediaFileURL) {
-      const file = await activeChannel.getMediaFile(message.mediaId, message.mime_type);
+      const file = await activeChannel.getMediaFile(message.mediaId, message.mime_type) as any;
 
       if (file) this.mediaFileURL = await this._uploadFile(endUserId, message.type, file.filePath, file.fileName) as string;
 

--- a/libs/functions/bot-engine/main/src/lib/services/media/process-media-service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/media/process-media-service.ts
@@ -17,9 +17,10 @@ import { ActiveChannel } from '../../model/active-channel.service';
  */
 export class BotMediaProcessService 
 {
-  private mediaFileURL: string = "";
+  private mediaFileURL = "";
 
-  constructor(private _tools: HandlerTools) { }
+  constructor(private _tools: HandlerTools, private isPreview?: boolean) 
+  { }
 
   /**
    * 
@@ -30,6 +31,12 @@ export class BotMediaProcessService
   {
     const orgId = activeChannel.channel.orgId;
 
+    let fileRepo$ = this._tools.getRepository<FileUpload>(`orgs/${orgId}/end-users/${endUserId}/files`);
+
+    if(this.isPreview) {
+      fileRepo$ = this._tools.getRepository<FileUpload>(`orgs/${orgId}/preview-channels/${endUserId}_${orgId}/files`);
+    }
+
     const mediaFileMessage = message as FileMessage;
 
     const mediaFileInfo: FileUpload = {
@@ -38,7 +45,6 @@ export class BotMediaProcessService
       mime_type: mediaFileMessage.mime_type
     };
 
-    const fileRepo$ = this._tools.getRepository<FileUpload>(`orgs/${orgId}/end-users/${endUserId}/files`);
 
     await fileRepo$.create(mediaFileInfo, mediaFileInfo.id);
 

--- a/libs/functions/bot-engine/main/src/lib/services/process-input/block-type/process-location-input.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/process-input/block-type/process-location-input.service.ts
@@ -10,12 +10,13 @@ import { ProcessInput } from "../process-input.class";
 import { StoryBlock } from "@app/model/convs-mgr/stories/blocks/main";
 
 import { IProcessInput } from "../models/process-input.interface";
+import { ActiveChannel } from "../../../model/active-channel.service";
 
 export class ProcessLocationInput extends ProcessInput<Location> implements IProcessInput
 {
-  constructor(tools: HandlerTools)
+  constructor(tools: HandlerTools,  _activeChannel: ActiveChannel)
   {
-    super(tools);
+    super(tools, _activeChannel);
   }
 
   public async handleInput(message: Message, lastBlock: StoryBlock, orgId: string, endUser: EndUser): Promise<boolean> 

--- a/libs/functions/bot-engine/main/src/lib/services/process-input/block-type/process-options-input.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/process-input/block-type/process-options-input.service.ts
@@ -9,12 +9,13 @@ import { ProcessInput } from "../process-input.class";
 import { StoryBlock, VariableTypes } from "@app/model/convs-mgr/stories/blocks/main";
 
 import { IProcessInput } from "../models/process-input.interface";
+import { ActiveChannel } from "../../../model/active-channel.service";
 
 export class ProcessOptionsInput extends ProcessInput<string> implements IProcessInput {
   tools: HandlerTools;
 
-  constructor(tools: HandlerTools){
-    super(tools)
+  constructor(tools: HandlerTools,  _activeChannel: ActiveChannel){
+    super(tools, _activeChannel);
     this.tools = tools;
   }
 

--- a/libs/functions/bot-engine/main/src/lib/services/process-input/block-type/process-text-input.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/process-input/block-type/process-text-input.service.ts
@@ -9,11 +9,12 @@ import { ProcessInput } from "../process-input.class";
 import { StoryBlock, StoryBlockTypes, VariableTypes } from "@app/model/convs-mgr/stories/blocks/main";
 
 import { IProcessInput } from "../models/process-input.interface";
+import { ActiveChannel } from "../../../model/active-channel.service";
 
 export class ProcessTextInput extends ProcessInput<string> implements IProcessInput {
 
-  constructor(tools: HandlerTools){
-    super(tools);
+  constructor(tools: HandlerTools, _activeChannel: ActiveChannel){
+    super(tools, _activeChannel);
   }
 
   public async handleInput(message: Message, lastBlock: StoryBlock, orgId: string, endUser: EndUser): Promise<boolean> 

--- a/libs/functions/bot-engine/main/src/lib/services/process-input/process-input.class.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/process-input/process-input.class.ts
@@ -10,8 +10,11 @@ export class ProcessInput<T>
 {
   protected variableName: string;
   protected savedInputs: {[key:string]:any};
+  private isPreview: boolean;
 
-  constructor(private _tools: HandlerTools, private _activeChannel?: ActiveChannel) { }
+  constructor(private _tools: HandlerTools, private _activeChannel: ActiveChannel) { 
+    this.isPreview = this._activeChannel.channel.type === 'preview';
+  }
 
   async saveInput(orgId: string, endUser: EndUser, inputValue: T, inputValueType: MessageTypes, type?: VariableTypes): Promise<boolean>
   {
@@ -20,7 +23,11 @@ export class ProcessInput<T>
     this.savedInputs = endUser.variables;
 
     try {
-      const endUserRepo$ = this._tools.getRepository<EndUser>(`orgs/${orgId}/end-users`);
+      let endUserRepo$ = this._tools.getRepository<EndUser>(`orgs/${orgId}/end-users`);
+
+      if(this.isPreview) {
+        endUserRepo$ = this._tools.getRepository<EndUser>(`orgs/${orgId}/preview-channels`);
+      }
 
       const updatedInputs = this.__updateInputs(this.savedInputs, inputValue, inputValueType, variableType);
 
@@ -84,5 +91,14 @@ export class ProcessInput<T>
         break;
     }
     return updatedInputs;
+  }
+
+  getPreviewMode() {
+    return this.isPreview;
+  }
+
+  setPreviewMode(preview: boolean) {
+    this.isPreview = preview;
+    return this.isPreview;
   }
 }

--- a/libs/functions/bot-engine/main/src/lib/services/process-input/process-input.factory.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/process-input/process-input.factory.ts
@@ -19,11 +19,11 @@ export class ProcessInputFactory
   processInput(message: Message, lastBlock: StoryBlock, orgId: string, endUser: EndUser) {
     switch (message.type) {
       case MessageTypes.TEXT:
-        return new ProcessTextInput(this.tools).handleInput(message, lastBlock, orgId, endUser);
+        return new ProcessTextInput(this.tools, this._activeChannel).handleInput(message, lastBlock, orgId, endUser);
       case MessageTypes.LOCATION:
-        return new ProcessLocationInput(this.tools).handleInput(message, lastBlock, orgId, endUser);
+        return new ProcessLocationInput(this.tools, this._activeChannel).handleInput(message, lastBlock, orgId, endUser);
       case MessageTypes.QUESTION:
-        return new ProcessOptionsInput(this.tools).handleInput(message, lastBlock, orgId, endUser);
+        return new ProcessOptionsInput(this.tools, this._activeChannel).handleInput(message, lastBlock, orgId, endUser);
       case MessageTypes.IMAGE:
         return new ProcessMediaInput(this.tools, this._activeChannel, this.processMediaService).handleInput(message, lastBlock, orgId, endUser);
       case MessageTypes.VIDEO:

--- a/libs/functions/bot-engine/main/src/lib/services/process-message/process-message.service.ts
+++ b/libs/functions/bot-engine/main/src/lib/services/process-message/process-message.service.ts
@@ -38,6 +38,7 @@ export class ProcessMessageService
     private _tools: HandlerTools,
     private _activeChannel: ActiveChannel,
     private _processMediaService$: BotMediaProcessService,
+    private _isPreview?: boolean
   ) { 
     this.channel = _activeChannel.channel;
   }
@@ -94,9 +95,11 @@ export class ProcessMessageService
     this.sideOperations.push(inputPromise);
 
     // upodate leaner progrress
-    const updateLearnersProgressPromise = updateLearnerProgress(currentStory, lastBlock, endUser, tools, orgId);
+    if(!this._isPreview) {
+      const updateLearnersProgressPromise = updateLearnerProgress(currentStory, lastBlock, endUser, tools, orgId);
+      this.sideOperations.push(updateLearnersProgressPromise);
+    }
 
-    this.sideOperations.push(updateLearnersProgressPromise);
 
     // Return the cursor updated with the next block in the story
     let {newCursor, nextBlock} = await this.__nextBlockService(currentCursor, lastBlock, orgId, currentStory, msg, endUser.id);

--- a/libs/functions/bot-engine/preview/.babelrc
+++ b/libs/functions/bot-engine/preview/.babelrc
@@ -1,0 +1,3 @@
+{
+  "presets": [["@nrwl/web/babel", { "useBuiltIns": "usage" }]]
+}

--- a/libs/functions/bot-engine/preview/.eslintrc.json
+++ b/libs/functions/bot-engine/preview/.eslintrc.json
@@ -1,0 +1,18 @@
+{
+  "extends": ["../../../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.ts", "*.tsx"],
+      "rules": {}
+    },
+    {
+      "files": ["*.js", "*.jsx"],
+      "rules": {}
+    }
+  ]
+}

--- a/libs/functions/bot-engine/preview/README.md
+++ b/libs/functions/bot-engine/preview/README.md
@@ -1,0 +1,11 @@
+# functions-bot-engine-preview
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test functions-bot-engine-preview` to execute the unit tests via [Jest](https://jestjs.io).
+
+## Running lint
+
+Run `nx lint functions-bot-engine-preview` to execute the lint via [ESLint](https://eslint.org/).

--- a/libs/functions/bot-engine/preview/jest.config.ts
+++ b/libs/functions/bot-engine/preview/jest.config.ts
@@ -1,0 +1,16 @@
+/* eslint-disable */
+export default {
+  displayName: 'functions-bot-engine-preview',
+  preset: '../../../../jest.preset.js',
+  globals: {
+    'ts-jest': {
+      tsconfig: '<rootDir>/tsconfig.spec.json',
+    },
+  },
+  testEnvironment: 'node',
+  transform: {
+    '^.+\\.[tj]sx?$': 'ts-jest',
+  },
+  moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
+  coverageDirectory: '../../../../coverage/libs/functions/bot-engine/preview',
+};

--- a/libs/functions/bot-engine/preview/src/index.ts
+++ b/libs/functions/bot-engine/preview/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/functions-bot-engine-preview';

--- a/libs/functions/bot-engine/preview/src/index.ts
+++ b/libs/functions/bot-engine/preview/src/index.ts
@@ -1,1 +1,1 @@
-export * from './lib/functions-bot-engine-preview';
+export * from './lib/preview-channel.handler';

--- a/libs/functions/bot-engine/preview/src/lib/functions-bot-engine-preview.spec.ts
+++ b/libs/functions/bot-engine/preview/src/lib/functions-bot-engine-preview.spec.ts
@@ -1,0 +1,7 @@
+import { functionsBotEnginePreview } from './functions-bot-engine-preview';
+
+describe('functionsBotEnginePreview', () => {
+  it('should work', () => {
+    expect(functionsBotEnginePreview()).toEqual('functions-bot-engine-preview');
+  });
+});

--- a/libs/functions/bot-engine/preview/src/lib/functions-bot-engine-preview.spec.ts
+++ b/libs/functions/bot-engine/preview/src/lib/functions-bot-engine-preview.spec.ts
@@ -1,7 +1,0 @@
-import { functionsBotEnginePreview } from './functions-bot-engine-preview';
-
-describe('functionsBotEnginePreview', () => {
-  it('should work', () => {
-    expect(functionsBotEnginePreview()).toEqual('functions-bot-engine-preview');
-  });
-});

--- a/libs/functions/bot-engine/preview/src/lib/functions-bot-engine-preview.ts
+++ b/libs/functions/bot-engine/preview/src/lib/functions-bot-engine-preview.ts
@@ -1,0 +1,3 @@
+export function functionsBotEnginePreview(): string {
+  return 'functions-bot-engine-preview';
+}

--- a/libs/functions/bot-engine/preview/src/lib/functions-bot-engine-preview.ts
+++ b/libs/functions/bot-engine/preview/src/lib/functions-bot-engine-preview.ts
@@ -1,3 +1,0 @@
-export function functionsBotEnginePreview(): string {
-  return 'functions-bot-engine-preview';
-}

--- a/libs/functions/bot-engine/preview/src/lib/preview-channel.handler.ts
+++ b/libs/functions/bot-engine/preview/src/lib/preview-channel.handler.ts
@@ -1,26 +1,32 @@
 import { HandlerTools } from '@iote/cqrs';
 
-import { FunctionHandler, RestResult200 } from '@ngfi/functions';
+import { FunctionHandler, RestResult } from '@ngfi/functions';
 
 import { EngineBotManager } from '@app/functions/bot-engine';
 
 import { Message } from '@app/model/convs-mgr/conversations/messages';
 import { CommunicationChannel } from '@app/model/convs-mgr/conversations/admin/system';
+import { PreviewActiveChannel } from './services/preview-active-channel';
+import { EndUser } from '@app/model/convs-mgr/conversations/chats';
 
-export class PreviewChannelReceiveHandler extends FunctionHandler<{message: Message, channel: CommunicationChannel}, RestResult200>
+export class PreviewChannelReceiveHandler extends FunctionHandler<{ message: Message, channel: CommunicationChannel; }, RestResult>
 {
-  public async execute(req: {message: Message, channel: CommunicationChannel}, context: any, tools: HandlerTools) 
+  public async execute(req: { message: Message, channel: CommunicationChannel; }, context: any, tools: HandlerTools) 
   {
-    
-    const engine = new EngineBotManager(tools, tools.Logger, null);
-    engine.setPreviewMode(true);
-    
     try {
-      
-      return {};
+      const previewActiveChannel = new PreviewActiveChannel(tools, req.channel);
+
+      const engine = new EngineBotManager(tools, tools.Logger, previewActiveChannel);
+      engine.setPreviewMode(true);
+
+      const endUser = {
+        id: req.channel.id,
+      } as EndUser;
+
+      return engine.run(req.message, endUser);
     } catch (error) {
-      
-      return {};
+      tools.Logger.error(() => `[PreviewChannelReceiveHandler].execute - Error:: ${error}`);
+      return { status: 500, message: error } as RestResult;
     }
   }
 }

--- a/libs/functions/bot-engine/preview/src/lib/preview-channel.handler.ts
+++ b/libs/functions/bot-engine/preview/src/lib/preview-channel.handler.ts
@@ -1,0 +1,26 @@
+import { HandlerTools } from '@iote/cqrs';
+
+import { FunctionHandler, RestResult200 } from '@ngfi/functions';
+
+import { EngineBotManager } from '@app/functions/bot-engine';
+
+import { Message } from '@app/model/convs-mgr/conversations/messages';
+import { CommunicationChannel } from '@app/model/convs-mgr/conversations/admin/system';
+
+export class PreviewChannelReceiveHandler extends FunctionHandler<{message: Message, channel: CommunicationChannel}, RestResult200>
+{
+  public async execute(req: {message: Message, channel: CommunicationChannel}, context: any, tools: HandlerTools) 
+  {
+    
+    const engine = new EngineBotManager(tools, tools.Logger, null);
+    engine.setPreviewMode(true);
+    
+    try {
+      
+      return {};
+    } catch (error) {
+      
+      return {};
+    }
+  }
+}

--- a/libs/functions/bot-engine/preview/src/lib/services/preview-active-channel.ts
+++ b/libs/functions/bot-engine/preview/src/lib/services/preview-active-channel.ts
@@ -1,0 +1,45 @@
+import { __DateFromStorage } from "@iote/time";
+import { HandlerTools } from "@iote/cqrs";
+
+import { __DECODE_AES } from "@app/elements/base/security-config";
+import { ActiveChannel, EndUserDataService } from "@app/functions/bot-engine";
+import { EndUser } from "@app/model/convs-mgr/conversations/chats";
+import { StoryBlock } from "@app/model/convs-mgr/stories/blocks/main";
+import { Message } from "@app/model/convs-mgr/conversations/messages";
+
+/**
+ * After the bot engine processes the incoming message and returns the next block,
+ *      the block is parsed through the @see {OutgoingMessageParser}, which returns a
+ *          a prepared  message that can be sent over the line to its specific channel API. 
+ * 
+ * @Description Model used to send the prepared messages through whatsApp api
+ * 
+ * @see https://developers.facebook.com/docs/messenger-platform/send-messages
+ * 
+ * @extends {ActiveChannel}
+ * 
+ * STEP 1: Assign the access token and the business phone number id
+ * STEP 2: Prepare the outgoing whatsapp message
+ * STEP 3: Send the message
+ */
+export class PreviewActiveChannel implements ActiveChannel
+{
+  channel: any;
+  endUserService: EndUserDataService;
+
+  constructor(private _tools: HandlerTools, channel: any)
+  {
+    this.channel = channel;
+    this.endUserService = new EndUserDataService(_tools, channel.orgId);
+  }
+  
+  parseOutMessage(storyBlock: StoryBlock, endUser: EndUser)
+  {
+    return {} as any;
+  }
+  
+  send(msg: any, standardMessage?: Message)
+  {
+    throw new Error("Method not implemented.");
+  }
+}

--- a/libs/functions/bot-engine/preview/tsconfig.json
+++ b/libs/functions/bot-engine/preview/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../../../tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ]
+}

--- a/libs/functions/bot-engine/preview/tsconfig.lib.json
+++ b/libs/functions/bot-engine/preview/tsconfig.lib.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs",
+    "outDir": "../../../../dist/out-tsc",
+    "declaration": true,
+    "types": ["node"]
+  },
+  "exclude": ["jest.config.ts", "**/*.spec.ts", "**/*.test.ts"],
+  "include": ["**/*.ts"]
+}

--- a/libs/functions/bot-engine/preview/tsconfig.spec.json
+++ b/libs/functions/bot-engine/preview/tsconfig.spec.json
@@ -1,0 +1,20 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../../../dist/out-tsc",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": [
+    "jest.config.ts",
+    "**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.tsx",
+    "**/*.spec.tsx",
+    "**/*.test.js",
+    "**/*.spec.js",
+    "**/*.test.jsx",
+    "**/*.spec.jsx",
+    "**/*.d.ts"
+  ]
+}

--- a/libs/model/convs-mgr/conversations/admin/system/src/lib/platform-types.enum.ts
+++ b/libs/model/convs-mgr/conversations/admin/system/src/lib/platform-types.enum.ts
@@ -18,6 +18,8 @@ export enum PlatformType
   Telegram  =  'telegram',
   /** Messenger API */
   Messenger =  'messenger',
+
+  Preview   = 'preview'
 }
 
 /**

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -217,6 +217,9 @@
       "@app/functions/bot-engine/messenger": [
         "libs/functions/bot-engine/messenger/src/index.ts"
       ],
+      "@app/functions/bot-engine/preview": [
+        "libs/functions/bot-engine/preview/src/index.ts"
+      ],
       "@app/functions/bot-engine/send-message": [
         "libs/functions/bot-engine/send-message/src/index.ts"
       ],


### PR DESCRIPTION
# Description

 Implement backend to support Web preview of bot. Just need to pass a standardized message and the preview channel details to communicate with the bot from the frontend.

I have restricted one channel per user in this case.

Channel details should be saved in `orgs/{orgId}/preview-channels/config`
