### PR TITLE
✨ ♻️ Add section to configure assessments instructions, question display format and retakes

### DIFF
--- a/apps/conv-learning-manager/src/assets/i18n/en.json
+++ b/apps/conv-learning-manager/src/assets/i18n/en.json
@@ -639,6 +639,29 @@
         "WRONG": "Wrong",
         "50-50": "50/50"
       }
+    },
+    "ASSESSMENT-CONFIGS": {
+      "QUES-PER-PAGE": "Questions per page",
+      "PER-PAGE-DESC": "Select the number of questions you'd like to display for the user's view",
+      "DISPLAY-OPTIONS": {
+        "SINGLE":"One question per page",
+        "MULTIPLE": "All questions on one page"
+      },
+      "RETRIAL": {
+        "ENABLE-RETRIAL": "Enable retrial",
+        "RETRIAL-TEXT": "Allow user to attempt the assesment more than once",
+        "RETRIAL-PROVISIONS": {
+          "DEFAULT": {
+            "DEFAULT-TEXT": "Retry anyway",
+            "TRIAL-NOS": "Maximum number of trials"
+          },
+          "ON-SCORE": {
+            "SCORE-TEXT": "Retry on score",
+            "MINIMUM-SCORE": "Minimum score",
+            "TRIAL-NOS": "Number of trials"
+          }
+        }
+      }
     }
   },
   "SURVEYS": {

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.html
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.html
@@ -42,9 +42,9 @@
             </div>
         </div>
         <div class="assessment-config">
-            <div class="enable-retrial" >
+            <div class="enable-retrial">
                 <h5>{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.ENABLE-RETRIAL' | transloco}}</h5> 
-                <mat-slide-toggle (change)="toggleRetry()"></mat-slide-toggle>
+                <mat-slide-toggle formControlName="canRetry" (change)="toggleRetry()"></mat-slide-toggle>
             </div>
             <span> {{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-TEXT' | transloco}}</span>
             <div class="retrial-allowed" *ngIf="retry">
@@ -52,15 +52,17 @@
                 <mat-radio-group formControlName="retryType" fxLayout="column" fxLayoutAlign="start">
                     <mat-radio-button [value]="defaultRetry">{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.DEFAULT.DEFAULT-TEXT' |
                         transloco}}</mat-radio-button>
+                        <div class="retry-configs">
+                            <div class="default-config" *ngIf="isDefaultRetrySelected">
+                                <span>{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.DEFAULT.TRIAL-NOS' | transloco}}</span>
+                                <input formControlName="userAttempts" type="number"/>
+                            </div>
+                        </div>    
                     <mat-radio-button [value]="scoreRetry">{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.ON-SCORE.SCORE-TEXT' |
                         transloco}}</mat-radio-button>
                 </mat-radio-group>
-                <div class="retry-configs" *ngIf="defaultRetry">
-                    <div class="default-config">
-                        <span>{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.DEFAULT.TRIAL-NOS' | transloco}}</span>
-                        <input formControlName="userAttempts" type="number"/>
-                    </div>
-                    <div class="score-config" *ngIf="scoreRetry" formGroupName="scoreAttempts">
+                <div class="retry-configs">
+                    <div class="score-config" *ngIf="isScoreRetrySelected" formGroupName="scoreAttempts">
                         <div class="score-descs">
                             <span>{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.ON-SCORE.MINIMUM-SCORE' | transloco}}</span>
                             <input formControlName="minScore" type="number"/>

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.html
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.html
@@ -1,4 +1,4 @@
-<div [formGroup]="assessmentFormGroup">
+<div *ngIf="assessmentFormGroup" [formGroup]="assessmentFormGroup">
     <!-- Commenting out feedback for now, as it is being build into microapps -->
     <!-- <h4>{{'ASSESSMENTS.QUESTIONS.FIELDS.CONFIGURATION' | transloco}}</h4>
     <div [formGroup]="assessmentFormGroup">
@@ -32,7 +32,7 @@
             <hr/>
             <div >
                 <div fxLayout="column" fxLayoutAlign="start" fxLayoutGap="2%">
-                    <mat-radio-group formControlName="feedback" fxLayout="column" fxLayoutAlign="start">
+                    <mat-radio-group formControlName="questionsDisplay" fxLayout="column" fxLayoutAlign="start">
                         <mat-radio-button [value]="singleDisplay">{{'ASSESSMENTS.ASSESSMENT-CONFIGS.DISPLAY-OPTIONS.SINGLE' |
                             transloco}}</mat-radio-button>
                         <mat-radio-button [value]="multipleDisplay">{{'ASSESSMENTS.ASSESSMENT-CONFIGS.DISPLAY-OPTIONS.MULTIPLE' |
@@ -49,7 +49,7 @@
             <span> {{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-TEXT' | transloco}}</span>
             <div class="retrial-allowed" *ngIf="retry">
                 <hr />
-                <mat-radio-group formControlName="feedback" fxLayout="column" fxLayoutAlign="start">
+                <mat-radio-group formControlName="retryType" fxLayout="column" fxLayoutAlign="start">
                     <mat-radio-button [value]="defaultRetry">{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.DEFAULT.DEFAULT-TEXT' |
                         transloco}}</mat-radio-button>
                     <mat-radio-button [value]="scoreRetry">{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.ON-SCORE.SCORE-TEXT' |
@@ -58,16 +58,16 @@
                 <div class="retry-configs" *ngIf="defaultRetry">
                     <div class="default-config">
                         <span>{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.DEFAULT.TRIAL-NOS' | transloco}}</span>
-                        <input  type="number"/>
+                        <input formControlName="userAttempts" type="number"/>
                     </div>
-                    <div class="score-config" *ngIf="scoreRetry">
+                    <div class="score-config" *ngIf="scoreRetry" formGroupName="scoreAttempts">
                         <div class="score-descs">
                             <span>{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.ON-SCORE.MINIMUM-SCORE' | transloco}}</span>
-                            <input  type="number"/>
+                            <input formControlName="minScore" type="number"/>
                         </div>
                         <div class="score-descs">
                             <span>{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.ON-SCORE.TRIAL-NOS' | transloco}}</span>
-                            <input  type="number"/>
+                            <input formControlName="userAttempts" type="number"/>
                         </div>
                     </div>
                 </div>

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.html
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.html
@@ -55,7 +55,7 @@
                         <div class="retry-configs">
                             <div class="default-config" *ngIf="isDefaultRetrySelected">
                                 <span>{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.DEFAULT.TRIAL-NOS' | transloco}}</span>
-                                <input formControlName="userAttempts" type="number"/>
+                                <input formControlName="userAttempts" type="number" min="0" max="100"/>
                             </div>
                         </div>    
                     <mat-radio-button [value]="scoreRetry">{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.ON-SCORE.SCORE-TEXT' |
@@ -65,11 +65,11 @@
                     <div class="score-config" *ngIf="isScoreRetrySelected" formGroupName="scoreAttempts">
                         <div class="score-descs">
                             <span>{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.ON-SCORE.MINIMUM-SCORE' | transloco}}</span>
-                            <input formControlName="minScore" type="number"/>
+                            <input formControlName="minScore" type="number" min="0" max="100"/>
                         </div>
                         <div class="score-descs">
                             <span>{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.ON-SCORE.TRIAL-NOS' | transloco}}</span>
-                            <input formControlName="userAttempts" type="number"/>
+                            <input formControlName="userAttempts" type="number" min="0"/>
                         </div>
                     </div>
                 </div>

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.html
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.html
@@ -1,5 +1,6 @@
-<div class="assessment-config">
-    <h4>{{'ASSESSMENTS.QUESTIONS.FIELDS.CONFIGURATION' | transloco}}</h4>
+<div [formGroup]="assessmentFormGroup">
+    <!-- Commenting out feedback for now, as it is being build into microapps -->
+    <!-- <h4>{{'ASSESSMENTS.QUESTIONS.FIELDS.CONFIGURATION' | transloco}}</h4>
     <div [formGroup]="assessmentFormGroup">
         <div formGroupName="configs" fxLayout="column" fxLayoutAlign="start" fxLayoutGap="2%">
 
@@ -21,6 +22,56 @@
                 </mat-label>
                 <input type="number" formControlName="userAttempts" matInput>
             </mat-form-field>
+        </div>
+    </div> -->
+
+    <div formGroupName="configs">
+        <div class="assessment-config">
+            <h5>{{'ASSESSMENTS.ASSESSMENT-CONFIGS.QUES-PER-PAGE' | transloco}}</h5>
+            <p> {{'ASSESSMENTS.ASSESSMENT-CONFIGS.PER-PAGE-DESC' | transloco}}</p>
+            <hr/>
+            <div >
+                <div fxLayout="column" fxLayoutAlign="start" fxLayoutGap="2%">
+                    <mat-radio-group formControlName="feedback" fxLayout="column" fxLayoutAlign="start">
+                        <mat-radio-button [value]="singleDisplay">{{'ASSESSMENTS.ASSESSMENT-CONFIGS.DISPLAY-OPTIONS.SINGLE' |
+                            transloco}}</mat-radio-button>
+                        <mat-radio-button [value]="multipleDisplay">{{'ASSESSMENTS.ASSESSMENT-CONFIGS.DISPLAY-OPTIONS.MULTIPLE' |
+                            transloco}}</mat-radio-button>
+                    </mat-radio-group>
+                </div>
+            </div>
+        </div>
+        <div class="assessment-config">
+            <div class="enable-retrial" >
+                <h5>{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.ENABLE-RETRIAL' | transloco}}</h5> 
+                <mat-slide-toggle (change)="toggleRetry()"></mat-slide-toggle>
+            </div>
+            <span> {{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-TEXT' | transloco}}</span>
+            <div class="retrial-allowed" *ngIf="retry">
+                <hr />
+                <mat-radio-group formControlName="feedback" fxLayout="column" fxLayoutAlign="start">
+                    <mat-radio-button [value]="defaultRetry">{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.DEFAULT.DEFAULT-TEXT' |
+                        transloco}}</mat-radio-button>
+                    <mat-radio-button [value]="scoreRetry">{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.ON-SCORE.SCORE-TEXT' |
+                        transloco}}</mat-radio-button>
+                </mat-radio-group>
+                <div class="retry-configs" *ngIf="defaultRetry">
+                    <div class="default-config">
+                        <span>{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.DEFAULT.TRIAL-NOS' | transloco}}</span>
+                        <input  type="number"/>
+                    </div>
+                    <div class="score-config" *ngIf="scoreRetry">
+                        <div class="score-descs">
+                            <span>{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.ON-SCORE.MINIMUM-SCORE' | transloco}}</span>
+                            <input  type="number"/>
+                        </div>
+                        <div class="score-descs">
+                            <span>{{'ASSESSMENTS.ASSESSMENT-CONFIGS.RETRIAL.RETRIAL-PROVISIONS.ON-SCORE.TRIAL-NOS' | transloco}}</span>
+                            <input  type="number"/>
+                        </div>
+                    </div>
+                </div>
+            </div>
         </div>
     </div>
 </div>

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.scss
@@ -37,7 +37,11 @@
 				gap: 15%;
 
 				input{
-					width: 40px;
+					width: 45px;
+					height: 23px;
+					outline: none;
+					border: 1px solid gray;
+					border-radius: 4px;
 				}
 			}
 			.score-config{
@@ -50,11 +54,15 @@
 					justify-content: space-between;
 					align-items: center;
 					padding-left: 8%;
-					padding-right: 47.8%;
+					padding-right: 47.5%;
 					padding-top: 0.5rem;
 
 					input{
-						width: 40px;
+						width: 45px;
+						height: 23px;
+						outline: none;
+						border: 1px solid gray;
+						border-radius: 4px;
 					}
 				}
 			}

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.scss
@@ -13,6 +13,53 @@
 		font-size: 1rem;
 		font-weight: 400;
 	}
+
+	.enable-retrial{
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		max-height: 40px;
+		padding: 0;
+		p{
+			margin: none;
+		}
+	}
+
+	.retrial-allowed{
+		.retry-configs{
+			display: flex;
+			flex-direction: column;
+			.default-config{
+				display: flex;
+				justify-content: start;
+				align-items: center;
+				padding-left: 8%;
+				gap: 15%;
+
+				input{
+					width: 40px;
+				}
+			}
+			.score-config{
+				display: flex;
+				flex-direction: column;
+				justify-content: space-between;
+	
+				.score-descs{
+					display: flex;
+					justify-content: space-between;
+					align-items: center;
+					padding-left: 8%;
+					padding-right: 47.8%;
+					padding-top: 0.5rem;
+
+					input{
+						width: 40px;
+					}
+				}
+			}
+		}
+	}
 }
 
 :host ::ng-deep .mdc-text-field--filled:not(.mdc-text-field--disabled) {

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.ts
@@ -1,4 +1,4 @@
-import { Component, Input } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
 import { Assessment, FeedbackType, QuestionDisplayed, RetryType } from '@app/model/convs-mgr/conversations/assessments';
@@ -8,7 +8,7 @@ import { Assessment, FeedbackType, QuestionDisplayed, RetryType } from '@app/mod
   templateUrl: './assessment-config.component.html',
   styleUrls: ['./assessment-config.component.scss'],
 })
-export class AssessmentConfigComponent {
+export class AssessmentConfigComponent implements OnInit{
   @Input() assessment: Assessment;
   @Input() assessmentMode: number
   @Input() assessmentFormGroup: FormGroup;
@@ -25,11 +25,23 @@ export class AssessmentConfigComponent {
   scoreRetry = RetryType.OnScore
   singleDisplay = QuestionDisplayed.Single
   multipleDisplay = QuestionDisplayed.Multiple
+
+  ngOnInit(): void {
+    this.retry = this.assessmentFormGroup?.get('configs.canRetry')?.value;
+  }
   
   toggleRetry(){
-    this.retry = !this.retry
+    const canRetry = this.assessmentFormGroup?.get('configs.canRetry')?.value;
+    this.assessmentFormGroup.get('configs.canRetry')?.setValue(!canRetry);
+    this.retry = !canRetry;
   }
 
-  
+  get isDefaultRetrySelected(): boolean {
+    return this.assessmentFormGroup?.get('configs.retryType')?.value === this.defaultRetry;
+  }
+
+  get isScoreRetrySelected(): boolean {
+    return this.assessmentFormGroup?.get('configs.retryType')?.value === this.scoreRetry;
+  }
 
 }

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.ts
@@ -29,4 +29,7 @@ export class AssessmentConfigComponent {
   toggleRetry(){
     this.retry = !this.retry
   }
+
+  
+
 }

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
-import { Assessment, FeedbackType } from '@app/model/convs-mgr/conversations/assessments';
+import { Assessment, FeedbackType, QuestionDisplayed, RetryType } from '@app/model/convs-mgr/conversations/assessments';
 
 @Component({
   selector: 'app-assessment-config',
@@ -14,9 +14,19 @@ export class AssessmentConfigComponent {
   @Input() assessmentFormGroup: FormGroup;
 
   @Input() previewMode: boolean;
+  /** If a user can retry an assignment  */
+  retry: boolean
 
+  /** Radio control values */
   immediateFeedback = FeedbackType.Immediately;
   onEndFeedback = FeedbackType.OnEnd;
   noFeedback = FeedbackType.Never;
+  defaultRetry = RetryType.Default
+  scoreRetry = RetryType.OnScore
+  singleDisplay = QuestionDisplayed.Single
+  multipleDisplay = QuestionDisplayed.Multiple
   
+  toggleRetry(){
+    this.retry = !this.retry
+  }
 }

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-question-forms/assessment-question-forms.component.html
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-question-forms/assessment-question-forms.component.html
@@ -13,6 +13,18 @@
     <button [disabled]="true" mat-mini-fab></button>
   </div>
 
+  <div class="card-area instructions-card" fxLayout="row" fxLayoutAlign="start">
+    <div class="card">
+      <div fxLayout="column" fxLayoutAlign="start">
+        <p> Assessment Instructions</p>
+        <mat-form-field appearance="fill" fxFlex="60">
+          <textarea type="textArea" matInput formControlName="instructions"></textarea>
+        </mat-form-field>
+      </div>
+    </div>
+    <button [disabled]="true" mat-mini-fab></button>
+  </div>
+
   <div *ngIf="questionsList.controls.length > 0; else noQuestions" formArrayName="questions" fxLayout="column"
     fxLayoutAlign="start" cdkDropList (cdkDropListDropped)="drop($event)">
     <div id="questions" *ngFor="let question of questionsList.controls; let i = index" fxFlex>

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-question-forms/assessment-question-forms.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-question-forms/assessment-question-forms.component.scss
@@ -30,6 +30,10 @@ button {
 	padding: 1.5rem 0;
 }
 
+.instructions-card{
+	margin-top: 1rem;
+}
+
 .btn-add {
 	width: 200px;
 	border: solid 1px var(--convs-mgr-color-primary-purple);

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/create-assessment-flow/create-assessment-page/create-assessment-page.component.html
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/create-assessment-flow/create-assessment-page/create-assessment-page.component.html
@@ -23,9 +23,9 @@
           </app-assessment-question-forms>
         </mat-tab>
         <!-- Temporarily removed the settings button since there is no feedback option as of now -->
-        <!-- <mat-tab label="Settings">
+        <mat-tab label="Settings">
           <app-assessment-config [previewMode]="false" [assessmentFormGroup]="assessmentFormModel.assessmentsFormGroup"></app-assessment-config>
-        </mat-tab> -->
+        </mat-tab>
         <mat-tab label="Preview">
           <!-- use the view component to create the form preview -->
           <app-assessment-view [assessmentForm]="assessmentFormModel.assessmentsFormGroup"></app-assessment-view>

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/create-assessment-flow/create-assessment-page/create-assessment-page.component.scss
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/create-assessment-flow/create-assessment-page/create-assessment-page.component.scss
@@ -63,6 +63,9 @@
 :host ::ng-deep .mat-mdc-tab.mdc-tab:last-child {
   border-radius: 0px 30px 30px 0px;
 }
+:host ::ng-deep .mat-mdc-tab.mdc-tab.mdc-tab--active {
+  border-radius: 30px;
+}
 
 :host ::ng-deep .mat-mdc-tab:not(.mat-mdc-tab-disabled).mdc-tab--active .mdc-tab__text-label,
 .mat-mdc-tab-link:not(.mat-mdc-tab-disabled).mdc-tab--active .mdc-tab__text-label {

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/create-assessment-flow/create-assessment-page/create-assessment-page.component.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/create-assessment-flow/create-assessment-page/create-assessment-page.component.ts
@@ -151,7 +151,9 @@ export class CreateAssessmentPageComponent implements OnInit, OnDestroy {
   {
     this.assessment['configs'] = {
       feedback: this.assessmentFormModel.assessmentsFormGroup.value.configs.feedback,
-      userAttempts: this.assessmentFormModel.assessmentsFormGroup.value.configs.userAttempts
+      userAttempts: this.assessmentFormModel.assessmentsFormGroup.value.configs.userAttempts,
+      retryType: this.assessmentFormModel.assessmentsFormGroup.value.configs.retryType,
+      questionsDisplay: this.assessmentFormModel.assessmentsFormGroup.value.configs.questionsDisplay
     };
 
     let questionsOrder = this.assessmentFormModel.assessmentsFormGroup.value.questionsOrder;

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/create-assessment-flow/create-assessment-page/create-assessment-page.component.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/create-assessment-flow/create-assessment-page/create-assessment-page.component.ts
@@ -151,6 +151,7 @@ export class CreateAssessmentPageComponent implements OnInit, OnDestroy {
   {
     this.assessment['configs'] = {
       feedback: this.assessmentFormModel.assessmentsFormGroup.value.configs.feedback,
+      canRetry: this.assessmentFormModel.assessmentsFormGroup.value.configs.canRetry,
       userAttempts: this.assessmentFormModel.assessmentsFormGroup.value.configs.userAttempts,
       retryType: this.assessmentFormModel.assessmentsFormGroup.value.configs.retryType,
       questionsDisplay: this.assessmentFormModel.assessmentsFormGroup.value.configs.questionsDisplay

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/providers/create-empty-assessment-form.provider.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/providers/create-empty-assessment-form.provider.ts
@@ -5,6 +5,7 @@ export function CREATE_EMPTY_ASSESSMENT_FORM(_fb: FormBuilder) {
   return _fb.group({
     // main part of form
     title: [''],
+    instructions: [[]],
     description: [''],
 
     questionsOrder: [[]],
@@ -23,6 +24,7 @@ export function CREATE_EMPTY_ASSESSMENT_FORM(_fb: FormBuilder) {
 export function DEFAULT_ASSESSMENT(): Assessment {
   return {
     title: '',
+    instructions: [],
     orgId: '',
     description: '',
     configs: {

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/providers/create-empty-assessment-form.provider.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/providers/create-empty-assessment-form.provider.ts
@@ -37,10 +37,11 @@ export function DEFAULT_ASSESSMENT(): Assessment {
       feedback: 1,
       userAttempts: 1,
       retryType: 1,
+      canRetry: false,
       questionsDisplay: 1,
       scoreAttempts: {
         minScore: 1,
-        userAttemps: 1
+        userAttempts: 1
       }
     },
   }

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/providers/create-empty-assessment-form.provider.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/providers/create-empty-assessment-form.provider.ts
@@ -13,7 +13,13 @@ export function CREATE_EMPTY_ASSESSMENT_FORM(_fb: FormBuilder) {
     // configs
     configs: _fb.group({
       feedback: [''],
-      userAttempts: ['']
+      userAttempts: [''],
+      retryType: [''],
+      questionsDisplay: [''],
+      scoreAttempts: _fb.group({
+        minScore: [''],
+        userAttempts: [''],
+      }),
     }),
 
     // quizzes
@@ -29,7 +35,13 @@ export function DEFAULT_ASSESSMENT(): Assessment {
     description: '',
     configs: {
       feedback: 1,
-      userAttempts: 1
+      userAttempts: 1,
+      retryType: 1,
+      questionsDisplay: 1,
+      scoreAttempts: {
+        minScore: 1,
+        userAttemps: 1
+      }
     },
   }
 }

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/services/assessment-form.service.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/services/assessment-form.service.ts
@@ -16,6 +16,7 @@ export class AssessmentFormService {
     return this._formBuilder.group({
       id: [assessment.id ?? ''],
       title: [assessment?.title ?? ''],
+      instructions: [assessment?.instructions ?? ''],
       questionsOrder: [assessment?.questionsOrder ?? []],
       configs: this._formBuilder.group({
         feedback: [assessment!.configs?.feedback ?? ''],

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/services/assessment-form.service.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/services/assessment-form.service.ts
@@ -19,8 +19,14 @@ export class AssessmentFormService {
       instructions: [assessment?.instructions ?? ''],
       questionsOrder: [assessment?.questionsOrder ?? []],
       configs: this._formBuilder.group({
-        feedback: [assessment!.configs?.feedback ?? ''],
-        userAttempts: [assessment!.configs?.userAttempts ?? '']
+        feedback: [assessment.configs?.feedback ?? ''],
+        userAttempts: [assessment.configs?.userAttempts ?? ''],
+        questionsDisplay: [assessment.configs?.questionsDisplay ?? ''],
+        retryType: [assessment.configs?.retryType ?? ''],
+        scoreAttempts: this._formBuilder.group({
+          minScore: [''],
+          userAttempts: [''],
+        }),
       }),
       questions: this._formBuilder.array([])
     });

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/services/assessment-form.service.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/services/assessment-form.service.ts
@@ -20,12 +20,13 @@ export class AssessmentFormService {
       questionsOrder: [assessment?.questionsOrder ?? []],
       configs: this._formBuilder.group({
         feedback: [assessment.configs?.feedback ?? ''],
+        canRetry: [assessment.configs?.canRetry ?? false],
         userAttempts: [assessment.configs?.userAttempts ?? ''],
         questionsDisplay: [assessment.configs?.questionsDisplay ?? ''],
         retryType: [assessment.configs?.retryType ?? ''],
         scoreAttempts: this._formBuilder.group({
-          minScore: [''],
-          userAttempts: [''],
+          minScore: [assessment.configs?.scoreAttempts?.minScore ?? ''],
+          userAttempts: [assessment.configs?.scoreAttempts?.userAttempts ?? ''],
         }),
       }),
       questions: this._formBuilder.array([])

--- a/libs/model/convs-mgr/conversations/assessments/src/lib/assessment.interface.ts
+++ b/libs/model/convs-mgr/conversations/assessments/src/lib/assessment.interface.ts
@@ -22,6 +22,8 @@ export interface AssessmentMetrics {
 export interface AssessmentConfiguration{
     feedback: FeedbackType,
     userAttempts?: number,
+    /** Is a user allowed to retake an assessment */
+    canRetry: boolean
     retryType?: RetryType,
     questionsDisplay: QuestionDisplayed,
     /** User attempts based on scores */
@@ -61,5 +63,5 @@ export enum QuestionDisplayed {
 
 export interface ScoreAttempType {
     minScore: number, 
-    userAttemps: number,
+    userAttempts: number,
 }

--- a/libs/model/convs-mgr/conversations/assessments/src/lib/assessment.interface.ts
+++ b/libs/model/convs-mgr/conversations/assessments/src/lib/assessment.interface.ts
@@ -23,6 +23,9 @@ export interface AssessmentConfiguration{
     feedback: FeedbackType,
     userAttempts?: number,
     retryType?: RetryType,
+    questionsDisplay: QuestionDisplayed,
+    /** User attempts based on scores */
+    scoreAttempts?: ScoreAttempType,
 }
 
 export interface ScoreCategory{
@@ -54,4 +57,9 @@ export enum RetryType {
 export enum QuestionDisplayed {
     Single = 1,
     Multiple = 2
+}
+
+export interface ScoreAttempType {
+    minScore: number, 
+    userAttemps: number,
 }

--- a/libs/model/convs-mgr/conversations/assessments/src/lib/assessment.interface.ts
+++ b/libs/model/convs-mgr/conversations/assessments/src/lib/assessment.interface.ts
@@ -21,7 +21,8 @@ export interface AssessmentMetrics {
 
 export interface AssessmentConfiguration{
     feedback: FeedbackType,
-    userAttempts?: number
+    userAttempts?: number,
+    retryType?: RetryType,
 }
 
 export interface ScoreCategory{
@@ -41,4 +42,16 @@ export enum CategoryType{
     Fail = 1,
     Pass = 2,
     Exceptional = 3
+}
+
+/** Mode of retry allowed, if any */
+export enum RetryType {
+    Default = 1,
+    OnScore = 2
+}
+
+/** How may questions to display per page */
+export enum QuestionDisplayed {
+    Single = 1,
+    Multiple = 2
 }

--- a/libs/model/convs-mgr/conversations/assessments/src/lib/assessment.interface.ts
+++ b/libs/model/convs-mgr/conversations/assessments/src/lib/assessment.interface.ts
@@ -2,6 +2,7 @@ import { Story } from "@app/model/convs-mgr/stories/main";
 
 export interface Assessment extends Story {
     title: string,
+    instructions: string[],
     description: string,
     orgId: string,
     configs?: AssessmentConfiguration,


### PR DESCRIPTION
# Description

1. Add a section where a content creator can add instructions on how the assessment is to be taken.
2. Add assessment configuration settings, for retakes and number of questions to be displayed in a page.

Fixes  CLM-435, CLM-436

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
