### PR TITLE
:bug: fix retry toggle

### DIFF
--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.ts
@@ -1,8 +1,9 @@
 import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
-import { Assessment, FeedbackType, QuestionDisplayed, RetryType } from '@app/model/convs-mgr/conversations/assessments';
 import { SubSink } from 'subsink';
+
+import { Assessment, FeedbackType, QuestionDisplayed, RetryType } from '@app/model/convs-mgr/conversations/assessments';
 
 @Component({
   selector: 'app-assessment-config',
@@ -66,6 +67,6 @@ export class AssessmentConfigComponent implements OnInit, OnDestroy
   }
 
   ngOnDestroy(): void {
-      this._sbS.unsubscribe()
+      this._sbS.unsubscribe();
   }
 }

--- a/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.ts
+++ b/libs/features/convs-mgr/conversations/assessments/src/lib/components/assessment-config/assessment-config.component.ts
@@ -1,16 +1,18 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnDestroy, OnInit } from '@angular/core';
 import { FormGroup } from '@angular/forms';
 
 import { Assessment, FeedbackType, QuestionDisplayed, RetryType } from '@app/model/convs-mgr/conversations/assessments';
+import { SubSink } from 'subsink';
 
 @Component({
   selector: 'app-assessment-config',
   templateUrl: './assessment-config.component.html',
   styleUrls: ['./assessment-config.component.scss'],
 })
-export class AssessmentConfigComponent implements OnInit{
+export class AssessmentConfigComponent implements OnInit, OnDestroy
+{
   @Input() assessment: Assessment;
-  @Input() assessmentMode: number
+  @Input() assessmentMode: number;
   @Input() assessmentFormGroup: FormGroup;
 
   @Input() previewMode: boolean;
@@ -21,19 +23,38 @@ export class AssessmentConfigComponent implements OnInit{
   immediateFeedback = FeedbackType.Immediately;
   onEndFeedback = FeedbackType.OnEnd;
   noFeedback = FeedbackType.Never;
-  defaultRetry = RetryType.Default
-  scoreRetry = RetryType.OnScore
-  singleDisplay = QuestionDisplayed.Single
-  multipleDisplay = QuestionDisplayed.Multiple
+  defaultRetry = RetryType.Default;
+  scoreRetry = RetryType.OnScore;
+  singleDisplay = QuestionDisplayed.Single;
+  multipleDisplay = QuestionDisplayed.Multiple;
+
+  private _sbS = new SubSink()
 
   ngOnInit(): void {
     this.retry = this.assessmentFormGroup?.get('configs.canRetry')?.value;
+    this._sbS.sink =  this.assessmentFormGroup?.get('configs.canRetry')?.valueChanges.subscribe((value) => {
+      this.retry = value;
+
+      if (!value) {
+        this.clearControls();
+      }
+    });
   }
   
-  toggleRetry(){
-    const canRetry = this.assessmentFormGroup?.get('configs.canRetry')?.value;
-    this.assessmentFormGroup.get('configs.canRetry')?.setValue(!canRetry);
-    this.retry = !canRetry;
+  /** Turn retry on or off.  */
+  toggleRetry(): void {
+    const canRetryControl = this.assessmentFormGroup.get('configs.canRetry');
+    if (canRetryControl) {
+     this.retry = canRetryControl.value;
+    }
+  }
+
+  /** If a user disables retry, clear out previous retry configurations */
+  clearControls(): void {
+    this.assessmentFormGroup.get('configs.retryType')?.setValue(null);
+    this.assessmentFormGroup.get('configs.userAttempts')?.setValue(null);
+    this.assessmentFormGroup.get('configs.scoreAttempts.minScore')?.setValue(null);
+    this.assessmentFormGroup.get('configs.scoreAttempts.userAttempts')?.setValue(null);
   }
 
   get isDefaultRetrySelected(): boolean {
@@ -44,4 +65,7 @@ export class AssessmentConfigComponent implements OnInit{
     return this.assessmentFormGroup?.get('configs.retryType')?.value === this.scoreRetry;
   }
 
+  ngOnDestroy(): void {
+      this._sbS.unsubscribe()
+  }
 }


### PR DESCRIPTION
# Description
Fix the on and off toggle for assessment retrials on the assessments configurations settings page

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my code
- [ ] My changes generate no new warnings
- [ ] New and existing unit tests pass locally with my changes
