### PR TITLE
💄  CLM 453 - Bots - search icon on bots home

### DIFF
--- a/libs/features/convs-mgr/stories/home/src/lib/components/bots/bots-list-all-courses/bots-list-all-courses.component.scss
+++ b/libs/features/convs-mgr/stories/home/src/lib/components/bots/bots-list-all-courses/bots-list-all-courses.component.scss
@@ -54,6 +54,7 @@ table {
 		color: gray;
 		font-size: 20px;
 		font-weight: 500;
+		padding-left: 0.5rem;
 	}
 
 	&_input {


### PR DESCRIPTION
# Description

Padding increase between search icon and left edge of search box.

Before:
![Capture2](https://github.com/user-attachments/assets/8217c746-3c56-440e-b4ce-3f41d24a1072)

After:
![Capture2](https://github.com/user-attachments/assets/e4bc8c00-ffb5-4aa6-9a18-e36f3423078f)



