### PR TITLE
💄  CLM 456 - Bots - module and lesson name bleeding over tile boundary

### DIFF
--- a/libs/features/convs-mgr/modules/src/lib/components/modules-lessons-grid-view/modules-lessons-grid-view.component.scss
+++ b/libs/features/convs-mgr/modules/src/lib/components/modules-lessons-grid-view/modules-lessons-grid-view.component.scss
@@ -76,6 +76,7 @@
     font-size: 1rem;
     padding: 0.2rem;
     text-wrap: wrap;
-    width: 60%;
+    width: 90%;
+    word-wrap: break-word;
   }
 }

--- a/libs/features/convs-mgr/stories/home/src/lib/components/modules/bot-modules-grid-view/bot-modules-grid-view.component.scss
+++ b/libs/features/convs-mgr/stories/home/src/lib/components/modules/bot-modules-grid-view/bot-modules-grid-view.component.scss
@@ -63,6 +63,8 @@
 
 .card-header {
   .name {
+    width: 90%;
+    word-wrap: break-word;
     font-size: 1rem;
     padding: 0.2rem;
   }


### PR DESCRIPTION
# Description

Fix module and lesson names overflow in bots

# Screenshots
Module:
![c1-a](https://github.com/user-attachments/assets/bb1e391c-700d-4263-9a4a-2c207bbc5e7e)
![c1-b](https://github.com/user-attachments/assets/6344a19a-e435-46cb-9713-17cbf6b5651c)


Lesson:
![c2-a](https://github.com/user-attachments/assets/f53d1951-eb22-4fd8-acb0-284eb8e01d86)
![c2-b](https://github.com/user-attachments/assets/92a976e1-c9e9-4c47-ba96-64c51a3ec86d)
