### PR TITLE
💬💄Clm 496 - Settings - Members - design changes

### DIFF
--- a/libs/elements/theming/_variables.scss
+++ b/libs/elements/theming/_variables.scss
@@ -14,6 +14,7 @@
   --convs-mgr-color-primary-dark-blue: #151B4A;
   --convs-mgr-color-primary-blue: #3e788a;
   --convs-mgr-color-bright-teal: #1F7A8C;
+  --convs-mgr-color-extra-bright-teal: #d1e3e7;
   --convs-mgr-color-primary-grey: #666;
   --convs-mgr-color-primary-light-grey: #f6f6f6;
   --convs-mgr-color-text-black: #263446;

--- a/libs/private/features/convs-mgr/settings/users/src/lib/components/users/users.component.html
+++ b/libs/private/features/convs-mgr/settings/users/src/lib/components/users/users.component.html
@@ -15,7 +15,7 @@
           <mat-form-field appearance="outline">
             <mat-select formControlName="role" placeholder="All Roles" multiple>
               <mat-option *ngFor="let role of orgRoles" [value]="role">
-                {{ role }}
+                {{ role | formatRole }}
               </mat-option>
             </mat-select>
           </mat-form-field>

--- a/libs/private/features/convs-mgr/settings/users/src/lib/components/users/users.component.scss
+++ b/libs/private/features/convs-mgr/settings/users/src/lib/components/users/users.component.scss
@@ -118,7 +118,7 @@
       overflow: auto;
       table{
         width: 100%;
-        background-color: var(--convs-mgr-color-F6F6F6);
+        background-color: var(--convs-mgr-color-text-white);
         
           th{
             // Name

--- a/libs/private/features/convs-mgr/settings/users/src/lib/custom-pipes/role.pipe.ts
+++ b/libs/private/features/convs-mgr/settings/users/src/lib/custom-pipes/role.pipe.ts
@@ -1,0 +1,11 @@
+import { Pipe, PipeTransform } from '@angular/core';
+
+@Pipe({
+    name: 'formatRole'
+})
+
+export class RolePipe implements PipeTransform {
+    transform(role: string){
+        return role.replace(/([a-z])([A-Z])/g, '$1 $2')
+    }
+}

--- a/libs/private/features/convs-mgr/settings/users/src/lib/modals/new-user-dialog/new-user-dialog.component.html
+++ b/libs/private/features/convs-mgr/settings/users/src/lib/modals/new-user-dialog/new-user-dialog.component.html
@@ -6,18 +6,20 @@
 <div class="new-clm-user" fxLayout="column" fxLayoutAlign="start" [formGroup]="newUserFormGroup"  mat-dialog-content>
  
     
-
-    <div fxLayout="column" fxLayoutAlign="start start" class="names">
+    <div class="email">
       <p class="label">*Email</p>
-      
-      <input matInput type="email" formControlName="email">
-      
+      <mat-form-field appearance="outline" fxLayout="column" fxLayoutAlign="start start" class="names">
+        <input matInput type="email" formControlName="email">
+      </mat-form-field>
     </div>
-    <div fxLayout="column" fxLayoutAlign="start start" class="names">
+
+    <div>
       <p class="label">Role</p>
-      <select name="roles" formControlName="roles">
-        <option *ngFor="let role of reversedRoles" [value]="role">{{ role | formatRole }}</option>
-      </select>
+      <mat-form-field appearance="outline" fxLayout="column" fxLayoutAlign="start start" class="names">
+        <mat-select name="roles" formControlName="roles" class="rolesSelect">
+          <mat-option *ngFor="let role of reversedRoles" [value]="role">{{ role | formatRole }}</mat-option>
+        </mat-select>
+      </mat-form-field>
     </div>
 
 

--- a/libs/private/features/convs-mgr/settings/users/src/lib/modals/new-user-dialog/new-user-dialog.component.html
+++ b/libs/private/features/convs-mgr/settings/users/src/lib/modals/new-user-dialog/new-user-dialog.component.html
@@ -16,7 +16,7 @@
     <div fxLayout="column" fxLayoutAlign="start start" class="names">
       <p class="label">Role</p>
       <select name="roles" formControlName="roles">
-        <option *ngFor="let role of reversedRoles" [value]="role">{{ role }}</option>
+        <option *ngFor="let role of reversedRoles" [value]="role">{{ role | formatRole }}</option>
       </select>
     </div>
 

--- a/libs/private/features/convs-mgr/settings/users/src/lib/modals/new-user-dialog/new-user-dialog.component.scss
+++ b/libs/private/features/convs-mgr/settings/users/src/lib/modals/new-user-dialog/new-user-dialog.component.scss
@@ -71,7 +71,7 @@
 }
 
 ::ng-deep.mat-mdc-select-panel .mat-mdc-option:hover {
-  background-color: var(--convs-mgr-color-bright-teal);
+  background-color: var(--convs-mgr-color-extra-bright-teal);
 }
 
 :host::ng-deep.mat-mdc-text-field-wrapper.mdc-text-field--outlined

--- a/libs/private/features/convs-mgr/settings/users/src/lib/modals/new-user-dialog/new-user-dialog.component.scss
+++ b/libs/private/features/convs-mgr/settings/users/src/lib/modals/new-user-dialog/new-user-dialog.component.scss
@@ -59,6 +59,12 @@
   background: transparent;
   height: 3rem;
 }
+:host::ng-deep.mat-mdc-select-value{
+  padding-top: 14px !important;
+}
+:host::ng-deep.mat-mdc-select-arrow-wrapper{
+  padding-top: 10px !important;
+}
 
 :host::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
   border-radius: 25px!important;

--- a/libs/private/features/convs-mgr/settings/users/src/lib/modals/new-user-dialog/new-user-dialog.component.scss
+++ b/libs/private/features/convs-mgr/settings/users/src/lib/modals/new-user-dialog/new-user-dialog.component.scss
@@ -46,7 +46,7 @@
     }
   }
   .buttons{
-    margin-top: 10px;
+    margin-top: 2rem;
   }
 }
 /* Add this to your existing styles */

--- a/libs/private/features/convs-mgr/settings/users/src/lib/modals/new-user-dialog/new-user-dialog.component.scss
+++ b/libs/private/features/convs-mgr/settings/users/src/lib/modals/new-user-dialog/new-user-dialog.component.scss
@@ -33,7 +33,9 @@
       font-size: 14px;
       font-family: Roboto;
       font-weight: 300;
-      word-wrap: break-word
+      word-wrap: break-word;
+      padding: 0;
+      margin: 0;
     }
     select,
     input{
@@ -58,6 +60,19 @@
   height: 3rem;
 }
 
-::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
+:host::ng-deep .mat-mdc-dialog-container .mdc-dialog__surface {
   border-radius: 25px!important;
 }
+
+::ng-deep.mat-mdc-select-panel .mat-mdc-option:hover {
+  background-color: var(--convs-mgr-color-bright-teal);
+}
+
+:host::ng-deep.mat-mdc-text-field-wrapper.mdc-text-field--outlined
+.mat-mdc-form-field-infix {
+  padding-top: 4px!important;
+  padding-bottom: 0px!important;
+}
+
+// :host::ng-deep.mat-mdc-form-field-type-mat-select:not(.mat-form-field-disabled) .mat-mdc-text-field-wrapper{
+// }

--- a/libs/private/features/convs-mgr/settings/users/src/lib/settings-users.module.ts
+++ b/libs/private/features/convs-mgr/settings/users/src/lib/settings-users.module.ts
@@ -11,6 +11,8 @@ import { UsersComponent } from './components/users/users.component';
 
 import { NewUserDialogComponent } from './modals/new-user-dialog/new-user-dialog.component';
 import { UpdateUserModalComponent } from './modals/update-user-modal/update-user-modal.component';
+import { RolePipe } from './custom-pipes/role.pipe';
+
 
 @NgModule({
   imports: [
@@ -29,7 +31,8 @@ import { UpdateUserModalComponent } from './modals/update-user-modal/update-user
   declarations: [
     UsersComponent,
     NewUserDialogComponent,
-    UpdateUserModalComponent
+    UpdateUserModalComponent,
+    RolePipe
   ],
   exports: [
     UsersComponent


### PR DESCRIPTION
# Description
Fix "Content Developer" typo in all roles dropdown and invite member modal.
Set the members table background to white.
Update hover color from blue to teal -> Role dropdown in the invite member modal.
Fix the dropdown icon placement.
Fix the width of the role input field to match the email width.
Increase the spacing between the role field and the call-to-action buttons.

# Screenshots
![Screenshot (1)](https://github.com/user-attachments/assets/65d95113-cfc1-4e20-b528-9627c5098fc0)
![Screenshot (2)](https://github.com/user-attachments/assets/354a1791-87f9-49a9-8ac2-0ace6161b3b0)
