### PR TITLE
🐛💄 CLM 479 - Chats - fix dead space on the bottom of the page

### DIFF
--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-conversation/chat-conversation.component.html
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chat-conversation/chat-conversation.component.html
@@ -17,7 +17,7 @@
 </div>
 
 <ng-template #noChat>
-  <div fxFlex fxLayout="column" fxLayoutAlign="center center" style="background-color: #ffffff;">
+  <div fxFlex fxLayout="column" fxLayoutAlign="center center">
     No Chat selected for display
   </div>
 </ng-template>

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chats-list/chats-list.component.html
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chats-list/chats-list.component.html
@@ -56,8 +56,12 @@
 
   <a class="current-page">{{currentPage}}</a>
 
-  <a (click)="move('future')"><i class="pagination-nav fa-solid fa-angle-right"></i></a>
-  <a (click)="goToPage(totalPageCount)"><i class="pagination-nav fa-solid fa-angle-double-right"></i></a>
+  <button (click)="move('future')" class="pagination-btn" [disabled]="currentPage >= totalPageCount + 1">
+    <i class="pagination-nav fa-solid fa-angle-right"></i>
+  </button>
+  <button (click)="goToPage(totalPageCount)" class="pagination-btn" [ngClass]="" [disabled]="currentPage >= totalPageCount + 1">
+    <i class="pagination-nav fa-solid fa-angle-double-right"></i>
+  </button>
 </div>
 
 </div>

--- a/libs/features/convs-mgr/conversations/chats/src/lib/components/chats-list/chats-list.component.scss
+++ b/libs/features/convs-mgr/conversations/chats/src/lib/components/chats-list/chats-list.component.scss
@@ -151,11 +151,11 @@ app-chat-card{
 	background-color: white;
 }
 
-.pagination a {
+.pagination a, .pagination-btn {
 	color: grey;
-  float: left;
-  padding: 0.5rem 1rem;
-  text-decoration: none;
+	float: left;
+	padding: 0.5rem 1rem;
+	text-decoration: none;
 	border-radius: 15px;
 	cursor: pointer;
 }
@@ -165,9 +165,14 @@ app-chat-card{
   color: white;
 }
 
-.pagination a:hover {
+.pagination a:hover, .pagination-btn:hover {
   background-color: var(--convs-mgr-color-primary-blue);
   color: white;
+}
+.pagination-btn {
+	font-size: 1rem;
+	border: none;
+	background: none;
 }
 
 .pagination-nav {


### PR DESCRIPTION
# Description
Remove white background in chat space.
Disable next buttons on reaching the last page of current chats.

# Screenshot 
<img width="1248" alt="Screenshot 2024-09-16 at 16 28 13" src="https://github.com/user-attachments/assets/6a094dc1-9f48-4e8d-ae3d-1ae9d7591de8">


