### PR TITLE
✨ 💄 Clm 550 - Phone Wrapper

### DIFF
--- a/apps/conv-learning-manager/src/assets/i18n/en.json
+++ b/apps/conv-learning-manager/src/assets/i18n/en.json
@@ -393,6 +393,7 @@
       "CONFIRM": "Confirm",
       "CANCEL": "Cancel"
     },
+    "BUTTON":"Button",
     "CONNECT-BOT-TO-CHANNEL":"Connect bot to channel",
     "PUBLISH-BOT":"Publish Bot",
     "ARCHIVE-BOT":"Archive Bot",

--- a/apps/conv-learning-manager/src/assets/i18n/en.json
+++ b/apps/conv-learning-manager/src/assets/i18n/en.json
@@ -396,7 +396,8 @@
     "CONNECT-BOT-TO-CHANNEL":"Connect bot to channel",
     "PUBLISH-BOT":"Publish Bot",
     "ARCHIVE-BOT":"Archive Bot",
-    "DELETE-BOT":"Delete Bot"
+    "DELETE-BOT":"Delete Bot",
+    "DRAG-ELEMENT": "Drag an element into this frame"
   },
   "MODULES": {
     "FIELDS": {

--- a/apps/conv-learning-manager/src/assets/i18n/en.json
+++ b/apps/conv-learning-manager/src/assets/i18n/en.json
@@ -400,6 +400,11 @@
     "DELETE-BOT":"Delete Bot",
     "DRAG-ELEMENT": "Drag an element into this frame"
   },
+  "FLOW-CATEGORY": {
+    "TEXT-ELS": "Text",
+    "DESIGN-ELS": "Design",
+    "INPUT-ELS": "Input"
+  },
   "MODULES": {
     "FIELDS": {
       "NAME": "Name",

--- a/apps/conv-learning-manager/src/assets/i18n/en.json
+++ b/apps/conv-learning-manager/src/assets/i18n/en.json
@@ -398,7 +398,8 @@
     "PUBLISH-BOT":"Publish Bot",
     "ARCHIVE-BOT":"Archive Bot",
     "DELETE-BOT":"Delete Bot",
-    "DRAG-ELEMENT": "Drag an element into this frame"
+    "DRAG-ELEMENT": "Drag an element into this frame",
+    "CHOOSE-FLOW-ELEMENT": "Choose Flow Element"
   },
   "FLOW-CATEGORY": {
     "TEXT-ELS": "Text",

--- a/apps/conv-learning-manager/src/assets/i18n/fr.json
+++ b/apps/conv-learning-manager/src/assets/i18n/fr.json
@@ -237,7 +237,8 @@
     "CONNECT-BOT-TO-CHANNEL":"Connecter le bot au canal",
     "PUBLISH-BOT":"Publier le robot",
     "ARCHIVE-BOT":"Bot d’archives",
-    "DELETE-BOT":"Supprimer le robot"
+    "DELETE-BOT":"Supprimer le robot",
+    "DRAG-ELEMENT": "Faites glisser un élément dans ce cadre"
 
   },
   "CLASSESS": {

--- a/apps/conv-learning-manager/src/assets/i18n/fr.json
+++ b/apps/conv-learning-manager/src/assets/i18n/fr.json
@@ -242,6 +242,11 @@
     "DRAG-ELEMENT": "Faites glisser un élément dans ce cadre"
 
   },
+"FLOW-CATEGORY": {
+  "TEXT-ELS": "Texte",
+  "DESIGN-ELS": "Conception",
+  "INPUT-ELS": "Saisir"
+},
   "CLASSESS": {
     "MODALS": {
       "CREATE-CLASS": "Créer une classe",

--- a/apps/conv-learning-manager/src/assets/i18n/fr.json
+++ b/apps/conv-learning-manager/src/assets/i18n/fr.json
@@ -239,7 +239,8 @@
     "PUBLISH-BOT":"Publier le robot",
     "ARCHIVE-BOT":"Bot d’archives",
     "DELETE-BOT":"Supprimer le robot",
-    "DRAG-ELEMENT": "Faites glisser un élément dans ce cadre"
+    "DRAG-ELEMENT": "Faites glisser un élément dans ce cadre",
+    "CHOOSE-FLOW-ELEMENT": "Choisir l'élément de flux"
 
   },
 "FLOW-CATEGORY": {

--- a/apps/conv-learning-manager/src/assets/i18n/fr.json
+++ b/apps/conv-learning-manager/src/assets/i18n/fr.json
@@ -234,6 +234,7 @@
       "CONFIRM": "Confirmer",
       "CANCEL": "Annuler"
     },
+    "BUTTON":"Bouton",
     "CONNECT-BOT-TO-CHANNEL":"Connecter le bot au canal",
     "PUBLISH-BOT":"Publier le robot",
     "ARCHIVE-BOT":"Bot d’archives",

--- a/libs/elements/theming/_variables.scss
+++ b/libs/elements/theming/_variables.scss
@@ -33,6 +33,7 @@
   --convs-mgr-medium-gray :#999;
   --convs-mgr-very-light-gray:#f0f0f0;
   --convs-mgr-color-secondary-teal: #266E7D;
+  --convs-mgr-color-lightgray: lightgray;
   --background-checked: #ffa225;
   --background-border: #DFE5F0;
   --conv-mgr-color-sidemenu-background: #7619FF26;

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.html
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.html
@@ -1,9 +1,10 @@
-<div fxFlexFill fxLayout="row" fxLayoutAlign="center center" class="flow-editor-container">
+<div fxFlexFill fxLayout="row" fxLayoutAlign="center" class="flow-editor-container">
   <div class="editor-container" >
     <!-- Image of the phone -->
-    <div id="phone-container" fxLayoutAlign="center center">
+    <div id="phone-container">
        <!-- Inner area inside the phone container. Smaller box centered into the phone, 
         making it look it's "behind" the phone image when in fact, it's in front. -->
+        <span></span>
       <div class="phone-inner">
         <!-- Fixed elements such as page title -->
 
@@ -38,11 +39,10 @@
       <ng-container #vcr> </ng-container>
       <input class="edit-btn" *ngIf="isEditing" placeholder="Button" />
     </div>
-  </div>
 
-
-  <div class="screen-config" *ngIf="droppedItems?.length > 0">
-    <lib-flow-screen-settings></lib-flow-screen-settings>
-  </div>
+    <div class="screen-config" *ngIf="droppedItems?.length > 0">
+      <lib-flow-screen-settings></lib-flow-screen-settings>
+    </div>
+</div>
 
 </div>

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.html
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.html
@@ -15,10 +15,17 @@
           [cdkDropListData]="droppedItems" 
           [cdkDropListConnectedTo]="['libraryDropList']" 
           (cdkDropListDropped)="drop($event)">
-          @for(item of droppedItems; track item)
-          {
-            <app-flow-library-item [control]="item" (click)="createField(item)" cdkDrag>  </app-flow-library-item>
-          }
+          <ng-container *ngIf="droppedItems.length > 0; else noDroppedItems">
+            @for(item of droppedItems; track item)
+            {
+              <app-flow-library-item [control]="item" (click)="createField(item)" cdkDrag>  </app-flow-library-item>
+            }
+          </ng-container>
+          <ng-template #noDroppedItems>
+            <div class="placeholder-text">
+              {{ 'BOTS.DRAG-ELEMENT' | transloco}}
+            </div>
+          </ng-template>
         </div>
 
         <!-- Fixed elements such as footer -->

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.html
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.html
@@ -20,7 +20,7 @@
             {
               <app-flow-library-item [control]="item" (click)="createField(item)" cdkDrag>  </app-flow-library-item>
             }
-            <button class="btn">Button</button>
+            <button (click)="editButton()">Button</button>  
           </ng-container>
 
           <ng-template #noDroppedItems>
@@ -36,6 +36,7 @@
 
     <div class="config-container" [ngClass]="droppedItems?.length > 0 ? 'edit-background': ''">
       <ng-container #vcr> </ng-container>
+      <input class="edit-btn" *ngIf="isEditing" placeholder="Button" />
     </div>
   </div>
 

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.html
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.html
@@ -20,7 +20,7 @@
             {
               <app-flow-library-item [control]="item" (click)="createField(item)" cdkDrag>  </app-flow-library-item>
             }
-            <button (click)="editButton()">Button</button>  
+            <button (click)="editButton()">{{ 'BOTS.BUTTON' | transloco}}</button>  
           </ng-container>
 
           <ng-template #noDroppedItems>

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.html
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.html
@@ -1,6 +1,5 @@
 <div fxFlexFill fxLayout="row" fxLayoutAlign="center center" class="flow-editor-container">
-
-  <div class="editor-container mat-elevation-z1" >
+  <div class="editor-container" >
     <!-- Image of the phone -->
     <div id="phone-container" fxLayoutAlign="center center">
        <!-- Inner area inside the phone container. Smaller box centered into the phone, 
@@ -10,7 +9,7 @@
 
         <!-- Target for custom elements-->
         <div id="flow-container-drop" 
-          *ngIf="droppedElements$ | async as droppedItems"
+          *ngIf="droppedItems"
           cdkDropList 
           [cdkDropListData]="droppedItems" 
           [cdkDropListConnectedTo]="['libraryDropList']" 
@@ -35,7 +34,7 @@
       </div>
     </div>
 
-    <div class="config-container">
+    <div class="config-container" [ngClass]="droppedItems?.length > 0 ? 'edit-background': ''">
       <ng-container #vcr> </ng-container>
     </div>
   </div>

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.html
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.html
@@ -14,13 +14,16 @@
           cdkDropList 
           [cdkDropListData]="droppedItems" 
           [cdkDropListConnectedTo]="['libraryDropList']" 
-          (cdkDropListDropped)="drop($event)">
+          (cdkDropListDropped)="drop($event)"
+        >
           <ng-container *ngIf="droppedItems.length > 0; else noDroppedItems">
             @for(item of droppedItems; track item)
             {
               <app-flow-library-item [control]="item" (click)="createField(item)" cdkDrag>  </app-flow-library-item>
             }
+            <button class="btn">Button</button>
           </ng-container>
+
           <ng-template #noDroppedItems>
             <div class="placeholder-text">
               {{ 'BOTS.DRAG-ELEMENT' | transloco}}

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.html
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.html
@@ -41,8 +41,8 @@
   </div>
 
 
-  <div class="screen-config">
-
+  <div class="screen-config" *ngIf="droppedItems?.length > 0">
+    <lib-flow-screen-settings></lib-flow-screen-settings>
   </div>
 
 </div>

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.html
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.html
@@ -1,5 +1,8 @@
 <div fxFlexFill fxLayout="row" fxLayoutAlign="center" class="flow-editor-container">
-  <div class="editor-container" >
+  <button *ngIf="!isSideScreenOpen" class="toggle-btn" (click)="toggleSidenav()">
+    <span><i class="fas fa-chevron-right"></i></span>
+  </button>
+  <div class="editor-container" [ngClass]="isSideScreenOpen? 'side-open': ''" >
     <!-- Image of the phone -->
     <div id="phone-container">
        <!-- Inner area inside the phone container. Smaller box centered into the phone, 
@@ -43,6 +46,6 @@
     <div class="screen-config" *ngIf="droppedItems?.length > 0">
       <lib-flow-screen-settings></lib-flow-screen-settings>
     </div>
-</div>
+  </div>
 
 </div>

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
@@ -33,7 +33,7 @@
     flex-direction: column;
     align-items: center;
     gap: 1rem;
-    padding: 0.5rem 0 0 0;
+    padding: 0.5rem 0.4rem 0 0;
 
     span {
       width: 60px;
@@ -72,7 +72,7 @@
       border-radius: 0.5rem;
       border: none;
       text-align: left;
-      width: 98%;
+      width: 100%;
       background: var(--convs-mgr-color-text-white);
       
       &:hover {

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
@@ -13,11 +13,11 @@
 }
 
   #phone-container {
-    width: 280px;
+    width: 500px;
     height: 585px;
     background-image: url(/assets/images/phone.png);
     background-size: cover;
-    background-color: white;
+    background-color: var(--convs-mgr-color-F6F6F6);
     border-radius:40px;
   }
   // Acts as an inner container into the phone image.
@@ -25,7 +25,16 @@
   .phone-inner {
     width: 260px;
     height: 520px;
-    background-color: red;
+  }
+
+  .placeholder-text {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 0.8rem;
+    color: var( --convs-mgr-medium-gray);
   }
 
   #flow-container-drop {

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
@@ -5,30 +5,43 @@
 .editor-container 
 {
   min-width: 800px;
-  height: fit content;
+  width: 100%;
+  height: fit-content;
 
-  margin-left: 8rem;
+  margin: 5rem 0 0 18rem;
   color: #101010;
   
   padding: 20px;
   display: flex;
   align-items: flex-start;
-  gap: 2rem;
+  gap: 1.5rem;
 }
 
   #phone-container {
-    width: 500px;
+    width: 520px;
     height: 585px;
-    background-image: url(/assets/images/phone.png);
+    border: 5px solid var(--convs-mgr-color-primary-black);
     background-size: cover;
     background-color: var(--convs-mgr-color-F6F6F6);
-    border-radius:40px;
+    border-radius: 1.25rem;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1rem;
+    padding: 0.5rem 0 0 0;
+
+    span {
+      width: 60px;
+      height: 8px;
+      border-radius: 1rem;
+      background-color: var(--convs-mgr-color-primary-black);
+    }
   }
   // Acts as an inner container into the phone image.
   //  Allowing us to move things inside.
   .phone-inner {
-    width: 260px;
-    height: 520px;
+    width: 290px;
+    height: 550px;
   }
 
   .placeholder-text {
@@ -45,8 +58,8 @@
     overflow-y: auto;
     display: flex;
     flex-direction: column;
-    padding: 12px 5px 12px 12px;
-    height: 92%;
+    padding: 0 5px 0 12px;
+    height: 97%;
 
     button {
       margin-top: auto;
@@ -68,7 +81,8 @@
     display: flex;
     flex-direction: column;
     gap: 0.8rem;
-    width: 100%;
+    width: 120%;
+
     border: 1 px solid black;
     border-radius: 10px;
     padding: 1.5rem;  
@@ -91,6 +105,7 @@
 }
 
 .screen-config {
+  width: 120%;
   padding: 1.2rem;
   border-radius: 0.625rem;
   background-color: var(--convs-mgr-color-text-white);

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
@@ -11,6 +11,7 @@
   
   padding: 20px;
   display: flex;
+  align-items: flex-start;
   gap: 2rem;
 }
 
@@ -46,14 +47,19 @@
     padding: 12px 5px 12px 12px;
     height: 92%;
 
-    .btn {
+    button {
       margin-top: auto;
       padding: 10px;
       border-radius: 0.5rem;
       border: none;
       text-align: left;
-      width: 100%;
+      width: 98%;
       background: var(--convs-mgr-color-text-white);
+      
+      &:hover {
+        cursor: pointer;
+        background-color: var(--convs-mgr-color-lightgray);
+      }
     }
   }
 
@@ -65,9 +71,21 @@
     border: 1 px solid black;
     border-radius: 10px;
     padding: 1.5rem;  
+    max-height: 490px;
+    overflow-y: auto;
     
     &.edit-background {
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
       background-color: var(--convs-mgr-color-text-white);
     }
   }
-  
+
+.edit-btn {
+  padding: 1rem 0 1rem 1rem;
+  border-radius: 0.25rem;
+  border: none;
+  background-color: var(--convs-mgr-color-F6F6F6);
+}
+

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
@@ -7,6 +7,7 @@
   min-width: 800px;
   height: fit content;
 
+  margin-left: 8rem;
   color: #101010;
   
   padding: 20px;
@@ -89,3 +90,8 @@
   background-color: var(--convs-mgr-color-F6F6F6);
 }
 
+.screen-config {
+  padding: 1.2rem;
+  border-radius: 0.625rem;
+  background-color: var(--convs-mgr-color-text-white);
+}

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
@@ -38,7 +38,9 @@
   }
 
   #flow-container-drop {
-    height: 100%;
+    overflow-y: auto;
+    padding: 12px 5px 12px 12px;
+    height: 92%;
   }
 
   .config-container{

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
@@ -7,11 +7,9 @@
   min-width: 800px;
   height: fit content;
 
-  background: #F6F6F6;
   color: #101010;
   
   padding: 20px;
-  border: 1px solid #101010;
   display: flex;
   gap: 2rem;
 }
@@ -66,7 +64,10 @@
     width: 100%;
     border: 1 px solid black;
     border-radius: 10px;
-    background-color: antiquewhite;
     padding: 1.5rem;  
+    
+    &.edit-background {
+      background-color: var(--convs-mgr-color-text-white);
+    }
   }
   

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
@@ -39,8 +39,20 @@
 
   #flow-container-drop {
     overflow-y: auto;
+    display: flex;
+    flex-direction: column;
     padding: 12px 5px 12px 12px;
     height: 92%;
+
+    .btn {
+      margin-top: auto;
+      padding: 10px;
+      border-radius: 0.5rem;
+      border: none;
+      text-align: left;
+      width: 100%;
+      background: var(--convs-mgr-color-text-white);
+    }
   }
 
   .config-container{

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.scss
@@ -8,13 +8,18 @@
   width: 100%;
   height: fit-content;
 
-  margin: 5rem 0 0 18rem;
+  margin: 5rem 0 0 5rem;
   color: #101010;
   
   padding: 20px;
   display: flex;
   align-items: flex-start;
   gap: 1.5rem;
+  transition: margin 0.3s ease;
+
+  &.side-open {
+    margin-left: 18rem;
+  }
 }
 
   #phone-container {
@@ -94,6 +99,22 @@
       flex-direction: column;
       justify-content: space-between;
       background-color: var(--convs-mgr-color-text-white);
+    }
+  }
+  
+  .toggle-btn { 
+    position: absolute;
+    left: 10px;
+    border: none;
+    transition: transform 0.3s ease;
+    cursor: pointer;
+    color: black;
+    padding: 10px;
+    background: none;
+  
+    z-index: 1000000;
+    .tooltip {
+      font-size: 1.2rem;
     }
   }
 

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.ts
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.ts
@@ -13,6 +13,7 @@ import { FlowControl } from '@app/model/convs-mgr/stories/flows';
 
 import { EditorComponentFactory } from '../../services/editor-component-factory.service';
 import { _GetFlowComponentForm } from '../../providers/flow-forms-build-factory.util';
+import { SideScreenToggleService } from '@app/features/convs-mgr/stories/builder/editor-state';
 
 
 @Component({
@@ -30,6 +31,7 @@ export class FlowEditorComponent implements OnInit, OnDestroy
   state: FlowBuilderStateFrame;
   droppedItems: any;
   isEditing = false;
+  isSideScreenOpen: boolean;
 
   constructor( private _flowBuilderState: FlowBuilderStateProvider,
                private editorComponentFactory: EditorComponentFactory,
@@ -37,9 +39,13 @@ export class FlowEditorComponent implements OnInit, OnDestroy
                private trackerService: ChangeTrackerService,
                private _wFlowService: WFlowService,
                private cdr: ChangeDetectorRef,
+               private sideScreen: SideScreenToggleService
   ) { }
   
   ngOnInit(): void {
+    this._sbS.sink = this.sideScreen.sideScreen$.subscribe((isOpen) => {
+      this.isSideScreenOpen = isOpen;
+    })
     this.droppedElements$ = this._flowBuilderState.getControls();
 
     this.droppedElements$.pipe(take(1)).subscribe((elements)=> {
@@ -52,6 +58,10 @@ export class FlowEditorComponent implements OnInit, OnDestroy
 
   editButton() {
     this.isEditing = true;
+  }
+
+  toggleSidenav(){
+    this.sideScreen.toggleSideScreen(!this.isSideScreenOpen);
   }
   
   /** Function handling drag and drop functionality for a component */

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.ts
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.ts
@@ -29,6 +29,7 @@ export class FlowEditorComponent implements OnInit, OnDestroy
   vcr!: ViewContainerRef;
   state: FlowBuilderStateFrame;
   droppedItems: any;
+  isEditing = false;
 
   constructor( private _flowBuilderState: FlowBuilderStateProvider,
                private editorComponentFactory: EditorComponentFactory,
@@ -47,6 +48,10 @@ export class FlowEditorComponent implements OnInit, OnDestroy
     })
 
     this._sbS.sink = this.trackerService.change$.subscribe();
+  }
+
+  editButton() {
+    this.isEditing = true;
   }
   
   /** Function handling drag and drop functionality for a component */

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.ts
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-editor/flow-editor.component.ts
@@ -28,6 +28,7 @@ export class FlowEditorComponent implements OnInit, OnDestroy
   @ViewChild('vcr', { static: true, read: ViewContainerRef })
   vcr!: ViewContainerRef;
   state: FlowBuilderStateFrame;
+  droppedItems: any;
 
   constructor( private _flowBuilderState: FlowBuilderStateProvider,
                private editorComponentFactory: EditorComponentFactory,
@@ -41,6 +42,7 @@ export class FlowEditorComponent implements OnInit, OnDestroy
     this.droppedElements$ = this._flowBuilderState.getControls();
 
     this.droppedElements$.pipe(take(1)).subscribe((elements)=> {
+      this.droppedItems = elements;
       elements.forEach(item => this.createField(item));
     })
 

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library-item/flow-library-item.component.html
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library-item/flow-library-item.component.html
@@ -1,6 +1,6 @@
 <div class="flow-lib-button" mat-raised-button>
   <i *ngIf="control?.icon" class="icon" [class]="control.icon"></i>
-  {{ control.label }}
+  <span>{{ control.label }}</span>
 
   <div >
     <i *ngIf="control.dropped" class="fa-solid fa-chevron-right drop-icon"></i>

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library-item/flow-library-item.component.html
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library-item/flow-library-item.component.html
@@ -2,7 +2,7 @@
   <i *ngIf="control?.icon" class="icon" [class]="control.icon"></i>
   <span>{{ control.label }}</span>
 
-  <div >
+  <!-- <div >
     <i *ngIf="control.dropped" class="fa-solid fa-chevron-right drop-icon"></i>
-  </div>
+  </div> -->
 </div>

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library-item/flow-library-item.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library-item/flow-library-item.component.scss
@@ -5,11 +5,12 @@
   width: -webkit-calc(100% - 24px);
   width: calc(100% - 24px);
 
-  border: 1px solid gray;
-  border-radius: 5px;
+  border-radius: 0.5rem;
   
   padding: 10px;
   margin-bottom: 5px;
+  font-size: 0.9rem;
+  background: var(--convs-mgr-color-text-white);
 }
   .flow-lib-button:hover {
     background-color: lightgray;

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library-item/flow-library-item.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library-item/flow-library-item.component.scss
@@ -1,13 +1,14 @@
 .flow-lib-button {
   display: flex;
   justify-content: space-between;
+  align-items: center;
   width: -moz-calc(100% - 24px);
   width: -webkit-calc(100% - 24px);
   width: calc(100% - 24px);
 
   border-radius: 0.5rem;
   
-  padding: 10px;
+  padding: 15px 10px;
   margin-bottom: 5px;
   font-size: 0.9rem;
   background: var(--convs-mgr-color-text-white);
@@ -19,4 +20,8 @@
 
 .icon {
   margin-right: 5px;
+}
+
+span {
+  font-size: 0.8rem;
 }

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library-item/flow-library-item.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library-item/flow-library-item.component.scss
@@ -1,14 +1,13 @@
 .flow-lib-button {
   display: flex;
-  justify-content: space-between;
   align-items: center;
   width: -moz-calc(100% - 24px);
   width: -webkit-calc(100% - 24px);
   width: calc(100% - 24px);
 
   border-radius: 0.5rem;
-  
-  padding: 15px 10px;
+  gap: 0.5rem;
+  padding: 15px 4px 15px 20px;
   margin-bottom: 5px;
   font-size: 0.9rem;
   background: var(--convs-mgr-color-text-white);

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library/flow-library.component.html
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library/flow-library.component.html
@@ -1,10 +1,23 @@
-<div class="nav">
+<div *ngIf="isSideScreenOpen" class="nav">
 
-  <div class="blocks-header" fxLayout="row">
-    <div><span class="header-title">Choose Element</span></div>
+  <div *ngIf="isSideScreenOpen" class="btn-wrapper" (click)="toggleSidenav()">
+    <i class="fas fa-chevron-left"></i>
+  </div>
+  <div class="blocks-header">
+    <span class="header-title">{{ 'BOTS.CHOOSE-FLOW-ELEMENT' | transloco}}</span>
 
     <div class="flex-spacer"></div>
   </div>
+
+  <div class="block-filters">
+    <div class="search">
+      <i class="fas fa-search search_tooltip"></i>
+      <input class="search_input" type="text" name="search table"
+        placeholder="Search element" id=""
+        >
+    </div>
+  </div>
+
 
   <mat-divider></mat-divider>
 

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library/flow-library.component.html
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library/flow-library.component.html
@@ -14,11 +14,11 @@
     #libraryDropList="cdkDropList" 
     [cdkDropListConnectedTo]="['flow-container-drop']"
   >
-    @for (group of controls; track group; let i=$index)
+    @for (group of groupedControls; track group; let i=$index)
     {
       <div class="block-list" fxLayout="column">
-        <h6 [class.first-title]="i === 0">{{ group.group| transloco }}</h6>
-        @for (control of controls; track control)
+        <h6 [class.first-title]="i === 0">{{ group.group | transloco }}</h6>
+        @for (control of group.controls; track control)
         {
           <!--CDK drag directive for elements that can be dragged-->
           <app-flow-library-item [control]="control" cdkDrag [cdkDragData]="control" >  

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library/flow-library.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library/flow-library.component.scss
@@ -2,7 +2,7 @@
   display: flex !important;
   flex-direction: column !important;
   justify-content: flex-start !important;
-  gap: 1.5rem;
+  gap: 1rem;
 
   min-width: 250px;
   height: -moz-calc(100% - 41.5px);
@@ -14,6 +14,7 @@
   scrollbar-gutter: stable both-edges;
   background-color: #F6F6F6;
   color: #101010;
+  transition: 0.2s ease;
 }
 .nav:hover {
   overflow-y: auto; 
@@ -22,8 +23,60 @@
   width: 5px; 
 }
 
+.btn-wrapper {
+  align-self: flex-end;
+  cursor: pointer;
+}
+
+.block-filters {
+  display: flex;
+  flex-direction: column;
+
+  ::placeholder {
+    font-size: small;
+    font-weight: 300;
+    color: var(--convs-mgr-color-101010);
+  }
+  
+  :-ms-input-placeholder { 
+    font-size: small;
+    font-weight: 300;
+    color: var(--convs-mgr-color-101010);
+  }
+  
+  ::-ms-input-placeholder { 
+    font-size: small;
+    font-weight: 300;
+    color: var(--convs-mgr-color-101010);
+   }
+}
+
+.search {
+  height: 5px;
+  width: calc(100% - 24px);
+  background-color: var(--convs-mgr-color-text-white);
+  border-radius: 30px;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 20px 4px 20px 20px;
+
+  &_tooltip {
+    color: var(--convs-mgr-color-101010);
+    font-size: 15px;
+    font-weight: 300 !important;
+  }
+
+  &_input {
+    width: 90%;
+    height: 30px;
+    border: none;
+    outline: none;
+    font-size: 15px;
+  }
+}
+
 .block-list {
-  padding: 5px 10px;
   color: rgba(0, 0, 0, 0.87);
   display: flex;
   flex-direction: row;
@@ -33,6 +86,8 @@
   cursor: move;
   gap: 0.5rem;
   background-color: var(--convs-mgr-color-F6F6F6);
+  margin-bottom: 1rem;
+  
   h6 {
     margin-bottom: 0.4rem;
     font-size: 0.8rem;

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library/flow-library.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library/flow-library.component.scss
@@ -26,7 +26,7 @@
   justify-content: space-between;
   box-sizing: border-box;
   cursor: move;
-  background: white;
+  background-color: var(--convs-mgr-color-F6F6F6);
   h6 {
     margin-bottom: 0.4rem;
     font-size: 0.8rem;

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library/flow-library.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library/flow-library.component.scss
@@ -11,14 +11,19 @@
   padding: 10px;
 
   overflow-y: hidden;
-  // scrollbar-gutter: stable both-edges;
+  scrollbar-gutter: stable both-edges;
   background-color: #F6F6F6;
   color: #101010;
+}
+.nav:hover {
+  overflow-y: auto; 
+}
+.nav::-webkit-scrollbar {
+  width: 5px; 
 }
 
 .block-list {
   padding: 5px 10px;
-  border-bottom: solid 1px #ccc;
   color: rgba(0, 0, 0, 0.87);
   display: flex;
   flex-direction: row;
@@ -26,12 +31,14 @@
   justify-content: space-between;
   box-sizing: border-box;
   cursor: move;
+  gap: 0.5rem;
   background-color: var(--convs-mgr-color-F6F6F6);
   h6 {
     margin-bottom: 0.4rem;
     font-size: 0.8rem;
     margin-top: 0px;
-    font-weight: 400;
+    font-weight: 500;
+    align-self: start;
 
     &:not(.first-title) {
       margin-top: 1rem;

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library/flow-library.component.ts
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library/flow-library.component.ts
@@ -1,7 +1,7 @@
 import { SubSink } from 'subsink';
 
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { FlowControl, FLOW_CONTROLS } from '@app/model/convs-mgr/stories/flows';
+import { FLOW_CONTROLS, FlowControl, GROUP_FLOW_CONTROL_GROUPS } from '@app/model/convs-mgr/stories/flows';
 // import { FlowEditorStateProvider } from '@app/state/convs-mgr/wflows';
 
 @Component({
@@ -13,8 +13,8 @@ export class FlowLibraryComponent implements OnInit, OnDestroy
 {
   private _sbS = new SubSink();
 
-  controls: FlowControl[]  = FLOW_CONTROLS();
-
+  controls: FlowControl[] = FLOW_CONTROLS();
+  groupedControls = GROUP_FLOW_CONTROL_GROUPS(this.controls);
 
   // constructor(private flowStateProvider: FlowEditorStateProvider) 
   // { }

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library/flow-library.component.ts
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-library/flow-library.component.ts
@@ -2,6 +2,7 @@ import { SubSink } from 'subsink';
 
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { FLOW_CONTROLS, FlowControl, GROUP_FLOW_CONTROL_GROUPS } from '@app/model/convs-mgr/stories/flows';
+import { SideScreenToggleService } from '@app/features/convs-mgr/stories/builder/editor-state';
 // import { FlowEditorStateProvider } from '@app/state/convs-mgr/wflows';
 
 @Component({
@@ -15,16 +16,25 @@ export class FlowLibraryComponent implements OnInit, OnDestroy
 
   controls: FlowControl[] = FLOW_CONTROLS();
   groupedControls = GROUP_FLOW_CONTROL_GROUPS(this.controls);
+  isSideScreenOpen: boolean;
 
-  // constructor(private flowStateProvider: FlowEditorStateProvider) 
-  // { }
+  constructor(
+    // private flowStateProvider: FlowEditorStateProvider,
+    private sideScreen: SideScreenToggleService
+  ) 
+  {}
 
   ngOnInit(): void {
-    // GROUP_FLOW_CONTROL_GROUPS(this.controls)
-    // console.log(this.controls)
-   }
+    this.sideScreen.sideScreen$.subscribe((isOpen) => {
+      this.isSideScreenOpen = isOpen;
+    })
+  }
+
+  toggleSidenav() {
+    this.sideScreen.toggleSideScreen(!this.isSideScreenOpen)
+  }
 
   ngOnDestroy(): void {
-      
+      this._sbS.unsubscribe();
   }
 }

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-screen-settings/flow-screen-settings.component.html
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-screen-settings/flow-screen-settings.component.html
@@ -1,0 +1,1 @@
+<p>screen-settings</p>

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-screen-settings/flow-screen-settings.component.ts
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-screen-settings/flow-screen-settings.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'lib-flow-screen-settings',
+  templateUrl: './flow-screen-settings.component.html',
+  styleUrl: './flow-screen-settings.component.scss',
+})
+export class FlowScreenSettingsComponent {}

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-type-text/flow-type-text.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-type-text/flow-type-text.component.scss
@@ -8,6 +8,7 @@
     width: 98%;
     padding: 1rem 0 1rem 1rem;
     border-radius: 4px;
-    border: none
+    border: none;
+    background-color: var(--convs-mgr-color-F6F6F6);
   }
 }

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-type-text/flow-type-text.component.scss
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/components/flow-type-text/flow-type-text.component.scss
@@ -1,3 +1,7 @@
+form{
+  width: 100%;
+}
+
 .wrapper{
   display: flex;
   width: 100%;

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/flow-builder.module.ts
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/flow-builder.module.ts
@@ -36,6 +36,7 @@ import { FlowButtonGroupComponent } from './components/flow-button-group/flow-bu
 import { FlowCheckboxOptionsComponent } from './components/flow-checkbox-options/flow-checkbox-options.component';
 import { TextAreaInputComponent } from './components/text-area-input/text-area-input.component';
 import { ImageTypeInputComponent } from './components/image-type-input/image-type-input.component';
+import { FlowScreenSettingsComponent } from './components/flow-screen-settings/flow-screen-settings.component';
 
 @NgModule({
   imports: [
@@ -62,6 +63,7 @@ import { ImageTypeInputComponent } from './components/image-type-input/image-typ
 
   declarations: [
     FlowEditorComponent,
+    FlowScreenSettingsComponent,
     FlowLibraryComponent,
     FlowPreviewComponent,
     FlowLibraryItemComponent,

--- a/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/pages/story-editor/flow-builder.page.html
+++ b/libs/features/convs-mgr/stories/builder/flow-builder/app/src/lib/pages/story-editor/flow-builder.page.html
@@ -19,7 +19,9 @@
   <mat-sidenav-container class="story-index" fxFlex="80" fxLayout="column" fxLayoutAlign="start" fxFlex>
 
     <!-- Left sidenav - Editor window -->
-    <mat-sidenav position="start" mode="side" [opened]="true"><app-flow-library></app-flow-library></mat-sidenav>
+    <mat-sidenav position="start" mode="side" [opened]="true">
+      <app-flow-library></app-flow-library>
+    </mat-sidenav>
 
     <!-- Right sidenav. Can be opened -->
     <mat-sidenav position="end" mode="over" #preview>

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -266,6 +266,9 @@
       ],
       "@app/functions/intent": ["libs/functions/intent/src/index.ts"],
       "@app/functions/user": ["libs/functions/user/src/index.ts"],
+      "@app/functions/whatsapp-flows": [
+        "libs/private/functions/whatsapp-flows/src/index.ts"
+      ],
       "@app/libs/private/features/convs-mgr/stories/builder/blocks/library/cmi5-block": [
         "libs/libs/private/features/convs-mgr/stories/builder/blocks/library/cmi5-block/src/index.ts"
       ],
@@ -511,8 +514,7 @@
       "@ngfi/functions/v2": ["libs/util/ngfi/functions-v2/src/index.ts"],
       "@ngfi/infinite-scroll": ["libs/util/ngfi/infinite-scroll/src/index.ts"],
       "@ngfi/multi-lang": ["libs/util/ngfi/multi-lang/src/index.ts"],
-      "@ngfi/state": ["libs/util/ngfi/state/src/index.ts"],
-      "@app/functions/whatsapp-flows": ["libs/private/functions/whatsapp-flows/src/index.ts"]
+      "@ngfi/state": ["libs/util/ngfi/state/src/index.ts"]
     }
   },
   "exclude": ["node_modules", "tmp"]


### PR DESCRIPTION
# Description

Display a phone frame that has a default message in the editor when the WhatsApp flow screen is opened.
Default message disappears when an element is dragged into the phone frame.
Dragging an element into the phone frame displays an edit screen, screen settings and a button at the bottom of the phone frame.
A scrollbar appears in the frame incase of many elements that exceed the frame's height.
Update stylings for the phone wrapper.


# Screenshot 
<img width="875" alt="Screenshot 2024-10-28 at 15 08 01" src="https://github.com/user-attachments/assets/9f60d6b6-d08d-469e-9741-26083536bc09">

<img width="370" alt="Screenshot 2024-10-28 at 15 06 46" src="https://github.com/user-attachments/assets/9903f771-8284-43f2-a72c-7d9483fd2c21">
